### PR TITLE
Resolve unmet peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "homepage": "https://github.com/kmagiera/react-native-screens#readme",
   "dependencies": {},
   "peerDependencies": {
-    "react": "16.0.0-alpha.6",
-    "react-native": "^0.44.1"
+    "react": "*",
+    "react-native": "*"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.3",


### PR DESCRIPTION
I do not see any specific features (maybe I missed something), but it seems reasonable to go for every `react` and `react-native` version if `react-navigation` does.

resolves #4 