### PR TITLE
fixes setActive method when the param is not int type in Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -20,8 +20,8 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
     return new Screen(reactContext);
   }
 
-  @ReactProp(name = "active", defaultInt = 0)
-  public void setActive(Screen view, int active) {
+  @ReactProp(name = "active", defaultFloat = 0)
+  public void setActive(Screen view, float active) {
     view.setActive(active != 0);
   }
 }


### PR DESCRIPTION
setActive method will receive double type,Double cannot be cast to java.lang.Integer