### PR TITLE
Add typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "precommit": "lint-staged"
   },
   "main": "src/screens.js",
+  "types": "src/screens.d.ts",
   "files": [
     "src/",
     "android/src/main/AndroidManifest.xml",

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -1,0 +1,19 @@
+// Project: https://github.com/kmagiera/react-native-screens
+// TypeScript Version: 2.8
+
+declare module 'react-native-screens' {
+  import { ComponentClass } from 'react';
+  import { ViewProps } from 'react-native';
+
+  export function useScreens(shouldUseScreens?: boolean): void;
+  export function screensEnabled(): boolean;
+  
+  export interface ScreenProps extends ViewProps {
+    active?: boolean;
+    onComponentRef?: (view: any) => void;
+  }
+  export const Screen: ComponentClass<ScreenProps>;
+
+  export type ScreenContainerProps = ViewProps;
+  export const ScreenContainer: ComponentClass<ScreenContainerProps>;
+}


### PR DESCRIPTION
Only type I'm worried about is `onComponentRef`. It's a callback that takes an instance of a `React.Component`, but that instance is typed as `any` within here.