### PR TITLE
Minimal support for other platforms

### DIFF
--- a/src/screens.js
+++ b/src/screens.js
@@ -5,6 +5,7 @@ import {
   View,
   UIManager,
   StyleSheet,
+  Platform,
 } from 'react-native';
 
 let USE_SCREENS = false;
@@ -22,14 +23,16 @@ export function screensEnabled() {
   return USE_SCREENS;
 }
 
-const NativeScreen = Animated.createAnimatedComponent(
-  requireNativeComponent('RNSScreen', null)
-);
+const isPlatformSupported = ['android', 'ios'].includes(Platform.OS);
 
-const NativeScreenContainer = requireNativeComponent(
+const NativeScreen = isPlatformSupported ? Animated.createAnimatedComponent(
+  requireNativeComponent('RNSScreen', null)
+) : null;
+
+const NativeScreenContainer = isPlatformSupported ? requireNativeComponent(
   'RNSScreenContainer',
   null
-);
+) : null;
 
 export class Screen extends React.Component {
   setNativeProps(props) {


### PR DESCRIPTION
Such as web and windows. `requireNativeComponent` is undefined on web.

This lives as a patch on [DailyScrum](https://github.com/Minishlink/DailyScrum/commit/3d6b5c45ae8ad4bf75cf61719c059bb6b1a42fa4) - web version.