### PR TITLE
Fix typo in updateContainer method definition

### DIFF
--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -17,7 +17,7 @@
 @property (nonatomic, retain) NSMutableSet<RNSScreenView *> *activeScreens;
 @property (nonatomic, retain) NSMutableArray<RNSScreenView *> *reactSubviews;
 
-- (void)updateConatiner;
+- (void)updateContainer;
 
 @end
 


### PR DESCRIPTION
It works anyway but causes a warning in xcode.