### PR TITLE
Use `commitAllowingStateLoss` instead of `commit`

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -96,7 +96,7 @@ public class ScreenContainer extends ViewGroup {
 
   private void tryCommitTransaction() {
     if (mCurrentTransaction != null) {
-      mCurrentTransaction.commit();
+      mCurrentTransaction.commitAllowingStateLoss();
       mCurrentTransaction = null;
     }
   }


### PR DESCRIPTION
This fixes a crash I saw in production on Android `java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState`. The fix is based on the comment here https://stackoverflow.com/questions/7575921/illegalstateexception-can-not-perform-this-action-after-onsaveinstancestate-wit.

The crash stopped happening since deploying this fix.

Fixes #20