### PR TITLE
Rename RNScreen to RNScreens to stay consistent

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.java
+++ b/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class RNScreenPackage implements ReactPackage {
+public class RNScreensPackage implements ReactPackage {
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     return Collections.emptyList();

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -42,7 +42,7 @@ public class ScreenContainer extends ViewGroup {
       mFragmentManager = ((FragmentActivity) activity).getSupportFragmentManager();
     } else {
       throw new IllegalStateException(
-              "In order to use RNScreen components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity");
+              "In order to use RNScreens components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity");
     }
   }
 

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainerViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainerViewManager.java
@@ -24,7 +24,7 @@ public class ScreenContainerViewManager extends ViewGroupManager<ScreenContainer
   @Override
   public void addView(ScreenContainer parent, View child, int index) {
     if (!(child instanceof Screen)) {
-      throw new IllegalArgumentException("Attempt attach child that is not of type RNScreen");
+      throw new IllegalArgumentException("Attempt attach child that is not of type RNScreens");
     }
     parent.addScreen((Screen) child, index);
   }


### PR DESCRIPTION
As discussed on slack, 

From @kmagiera 
> Definitely a typo, when strayed the project i named it screen (no s) but some time later realized that name's been taken on npm and elsewhere

PLEASE warn users as this is breaking and they need to change MainApplication.java to add *s*