### PR TITLE
Use `getViewManagerConfig` when available to remove warning

### DIFF
--- a/src/screens.native.js
+++ b/src/screens.native.js
@@ -9,9 +9,16 @@ import {
 
 let USE_SCREENS = false;
 
+// UIManager[`${moduleName}`] is deprecated in RN 0.58 and `getViewManagerConfig` is added.
+// We can remove this when we drop support for RN < 0.58.
+const getViewManagerConfigCompat = name =>
+  typeof UIManager.getViewManagerConfig !== 'undefined'
+    ? UIManager.getViewManagerConfig(name)
+    : UIManager[name];
+
 export function useScreens(shouldUseScreens = true) {
   USE_SCREENS = shouldUseScreens;
-  if (USE_SCREENS && !UIManager['RNSScreen']) {
+  if (USE_SCREENS && !getViewManagerConfigCompat('RNSScreen')) {
     console.error(
       `Screen native module hasn't been linked. Please check the react-native-screens README for more details`
     );


### PR DESCRIPTION
https://github.com/facebook/react-native/commit/aac7c4d5d24787f46ad1745204748c533554489e#diff-2527fb9fd9c4888767c90b634276a93b deprecates `UIManager['${moduleName}']` and adds `getViewManagerConfig`. This uses this method when available to preserve backwards compatibility. We can remove the compat method when we stop supporting RN < 0.58.