### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,13 +1,12 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
     dependencies {
-        // Matches the RN Hello World template
-        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L8
-        classpath 'com.android.tools.build:gradle:2.2.3'
+       classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 


### PR DESCRIPTION
gradle 2.2.1 is no more resolved on maven. This resuts in a build error like:

```
* What went wrong:
A problem occurred configuring project ':react-native-image-picker'.
> Could not resolve all artifacts for configuration ':react-native-image-picker:classpath'.
   > Could not find any matches for com.android.tools.build:gradle:2.2.+ as no versions of com.android.tools.build:gradle are available.
     Searched in the following locations:
       - https://jcenter.bintray.com/com/android/tools/build/gradle/maven-metadata.xml
       - https://jcenter.bintray.com/com/android/tools/build/gradle/
     Required by:
         project :react-native-image-picker
```

RNSvg already fix here : https://github.com/react-native-community/react-native-svg/commit/e48dbdb08b6fdc587ff1f8b53443110a860d8fbc#diff-c31b32364ce19ca8fcd150a417ecce58