### PR TITLE
Restore first responder of view controller when screen reactivates

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -13,6 +13,8 @@
 @property (nonatomic, retain) UIViewController *controller;
 @property (nonatomic) BOOL active;
 
+- (void)notifyFinishTransitioning;
+
 @end
 
 @interface UIView (RNSScreen)

--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -109,20 +109,33 @@
     }
   }
 
-  // add new screens in order they are placed in subviews array
-  for (RNSScreenView *screen in _reactSubviews) {
-    if (screen.active && ![_activeScreens containsObject:screen]) {
-      [_activeScreens addObject:screen];
-      [self attachScreen:screen];
-    } else if (screen.active && activeScreenAdded) {
-      // if we are adding new active screen, we perform remounting of all already marked as active
-      // this is done to mimick the effect UINavigationController has when willMoveToWindow:nil is
-      // triggered before the animation starts
-      if (activeScreenAdded) {
+  // if we are adding new active screen, we perform remounting of all already marked as active
+  // this is done to mimick the effect UINavigationController has when willMoveToWindow:nil is
+  // triggered before the animation starts
+  if (activeScreenAdded) {
+    for (RNSScreenView *screen in _reactSubviews) {
+      if (screen.active && [_activeScreens containsObject:screen]) {
         [self detachScreen:screen];
+        // disable interactions for the duration of transition
+        screen.userInteractionEnabled = NO;
+      }
+    }
+
+    // add new screens in order they are placed in subviews array
+    for (RNSScreenView *screen in _reactSubviews) {
+      if (screen.active) {
         [self attachScreen:screen];
       }
     }
+  }
+
+  // if we are down to one active screen it means the transitioning is over and we want to notify
+  // the transition has finished
+  if (activeScreenRemoved && _activeScreens.count == 1) {
+    RNSScreenView *singleActiveScreen = [_activeScreens anyObject];
+    // restore interactions
+    singleActiveScreen.userInteractionEnabled = YES;
+    [singleActiveScreen notifyFinishTransitioning];
   }
 
   if ((activeScreenRemoved || activeScreenAdded) && _controller.presentedViewController == nil) {


### PR DESCRIPTION
This change automates first responder restoring when screen is deactivated and the activated back (e.g. when we push new screen on top and then go back). In addition we disable pointerEvent setting for the Screen component as changes made to that prop would cause underlying views to resign responder before we can remember it. Because of that we add an automatic handling for pointer events for the Screen component that disables all touch interactions when screen is transitioning.