### PR TITLE
Ignore pointerEvent set via react props

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -31,6 +31,12 @@
   }
 }
 
+- (void)setPointerEvents:(RCTPointerEvents)pointerEvents
+{
+  // pointer events settings are managed by the parent screen container, we ignore any attempt
+  // of setting that via React props
+}
+
 - (UIView *)reactSuperview
 {
   return _reactSuperview;


### PR DESCRIPTION
This is a follow up to #48 which makes Screen component ignore setting of pointerEvents. As it turns out react-navigation tries to set this setting and in addition to handling it manually we also need to prevent it to be set via React prop.