### PR TITLE
Android alpha compositing

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -2,6 +2,7 @@ package com.swmansion.rnscreens;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.graphics.Paint;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -36,6 +37,7 @@ public class Screen extends ViewGroup {
   private final Fragment mFragment;
   private @Nullable ScreenContainer mContainer;
   private boolean mActive;
+  private boolean mTransitioning;
 
   public Screen(Context context) {
     super(context);
@@ -45,6 +47,33 @@ public class Screen extends ViewGroup {
   @Override
   protected void onLayout(boolean b, int i, int i1, int i2, int i3) {
     // no-op
+  }
+
+  /**
+   * While transitioning this property allows to optimize rendering behavior on Android and provide
+   * a correct blending options for the animated screen. It is turned on automatically by the container
+   * when transitioning is detected and turned off immediately after
+   */
+  public void setTransitioning(boolean transitioning) {
+    if (mTransitioning == transitioning) {
+      return;
+    }
+    mTransitioning = transitioning;
+    super.setLayerType(transitioning ? View.LAYER_TYPE_HARDWARE : View.LAYER_TYPE_NONE, null);
+  }
+
+  @Override
+  public boolean hasOverlappingRendering() {
+    return mTransitioning;
+  }
+
+  @Override
+  public void setLayerType(int layerType, @Nullable Paint paint) {
+    // ignore – layer type is controlled by `transitioning` prop
+  }
+
+  public void setNeedsOffscreenAlphaCompositing(boolean needsOffscreenAlphaCompositing) {
+    // ignore - offscreen alpha is controlled by `transitioning` prop
   }
 
   protected void setContainer(@Nullable ScreenContainer mContainer) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -158,6 +158,15 @@ public class ScreenContainer extends ViewGroup {
       }
     }
 
+    // detect if we are "transitioning" based on the number of active screens
+    int activeScreens = 0;
+    for (int i = 0, size = mScreens.size(); i < size; i++) {
+      if (isScreenActive(mScreens.get(i), mScreens)) {
+        activeScreens += 1;
+      }
+    }
+    boolean transitioning = activeScreens > 1;
+
     // attach newly activated screens
     boolean addedBefore = false;
     for (int i = 0, size = mScreens.size(); i < size; i++) {
@@ -169,6 +178,7 @@ public class ScreenContainer extends ViewGroup {
       } else if (isActive && addedBefore) {
         moveToFront(screen);
       }
+      screen.setTransitioning(transitioning);
     }
     tryCommitTransaction();
   }

--- a/src/screens.native.js
+++ b/src/screens.native.js
@@ -6,6 +6,7 @@ import {
   UIManager,
   StyleSheet,
 } from 'react-native';
+import { version } from 'react-native/Libraries/Core/ReactNativeVersion';
 
 let USE_SCREENS = false;
 
@@ -56,20 +57,19 @@ export class Screen extends React.Component {
       const { active, onComponentRef, ...props } = this.props;
 
       return <Animated.View {...props} ref={this.setRef} />;
+    } else if (version.minor >= 57) {
+      return <AnimatedNativeScreen {...this.props} />;
     } else {
+      // On RN version below 0.57 we need to wrap screen's children with an
+      // additional View because of a bug fixed in react-native/pull/20658 which
+      // was preventing a view from having both styles and some other props being
+      // "animated" (using Animated native driver)
       const { style, children, ...rest } = this.props;
       return (
         <AnimatedNativeScreen
           {...rest}
           ref={this.setRef}
           style={StyleSheet.absoluteFill}>
-          {/*
-            We need to wrap children in additional Animated.View because
-            of a bug in native driver preventing from both `active` and `styles`
-            props begin animated in `NativeScreen` component. Once
-            react-native/pull/20658 is merged we can export native screen directly
-            and avoid wrapping with `Animated.View`.
-          */}
           <Animated.View style={style}>{children}</Animated.View>
         </AnimatedNativeScreen>
       );


### PR DESCRIPTION
This change adds an ability for screen container on Android to apply the correct mechanism for transparent layer blending. This is specifically important as screens are usually a complex views that may displays many layers and while transitioning often opacity is used to animate these. When we detect screen transitioning we (a) turn on offscreen alpha compositing (which makes the opacity being applied for the whole screen layer at once instead of making all the children semi-transparent) and also (b) turn on hardware layer that makes offscreen compositing render to GPU (which is both faster and consumes only GPU memory).

In addition to that change we also need to disable wrapping Screen's children with View, as in such a case opacity is applied on the underlying View instead of a Screen. That workaround has been added because of a bug in Animated library and fixed in RN 0.57+