### PR TITLE
Make sure we access fragment manager only when view is attached (activity is foregrounded)

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -22,7 +22,6 @@ public class ScreenContainer extends ViewGroup {
 
   private final ArrayList<Screen> mScreens = new ArrayList<>();
   private final Set<Screen> mActiveScreens = new HashSet<>();
-  private final FragmentManager mFragmentManager;
 
   private @Nullable FragmentTransaction mCurrentTransaction;
   private boolean mNeedUpdate;
@@ -37,13 +36,6 @@ public class ScreenContainer extends ViewGroup {
 
   public ScreenContainer(Context context) {
     super(context);
-    Activity activity = ((ReactContext) context).getCurrentActivity();
-    if (activity instanceof FragmentActivity) {
-      mFragmentManager = ((FragmentActivity) activity).getSupportFragmentManager();
-    } else {
-      throw new IllegalStateException(
-              "In order to use RNScreens components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity");
-    }
   }
 
   @Override
@@ -88,8 +80,14 @@ public class ScreenContainer extends ViewGroup {
 
   private FragmentTransaction getOrCreateTransaction() {
     if (mCurrentTransaction == null) {
-      mCurrentTransaction = mFragmentManager.beginTransaction();
-      mCurrentTransaction.setReorderingAllowed(true);
+      Activity activity = ((ReactContext) getContext()).getCurrentActivity();
+      if (activity instanceof FragmentActivity) {
+        mCurrentTransaction = ((FragmentActivity) activity).getSupportFragmentManager().beginTransaction();
+        mCurrentTransaction.setReorderingAllowed(true);
+      } else {
+        throw new IllegalStateException(
+                "In order to use RNScreens components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity");
+      }
     }
     return mCurrentTransaction;
   }
@@ -136,7 +134,7 @@ public class ScreenContainer extends ViewGroup {
   }
 
   private void updateIfNeeded() {
-    if (!mNeedUpdate || mFragmentManager.isDestroyed() || !mIsAttached) {
+    if (!mNeedUpdate || !mIsAttached) {
       return;
     }
     mNeedUpdate = false;


### PR DESCRIPTION
This change makes us reach to fragment manager only when screen container is attached to window (and therefore we are sure that the current activity is react one). The problem reported in #33 was due to the fact we'd do that when container is instantiated which does not necessarily mean that react activity is in foreground. We didn't need to actually access fragment manager while not in foreground so this change removes fragmentManager as a member and we get it directly from context when needed.

Supposedly fixes #33 
