### PR TITLE
Restore view interaction when container changes from 0 active to 1 active

### DIFF
--- a/ios/RNSScreenContainer.m
+++ b/ios/RNSScreenContainer.m
@@ -131,7 +131,7 @@
 
   // if we are down to one active screen it means the transitioning is over and we want to notify
   // the transition has finished
-  if (activeScreenRemoved && _activeScreens.count == 1) {
+  if ((activeScreenRemoved || activeScreenAdded) && _activeScreens.count == 1) {
     RNSScreenView *singleActiveScreen = [_activeScreens anyObject];
     // restore interactions
     singleActiveScreen.userInteractionEnabled = YES;


### PR DESCRIPTION
Previously we weren't triggering transaction finish when going from none active screens to 1 active screen. This turns out to be the case in tab navigator where for a sub-frame moment the active state changes for the current screen to `NO` and then new screen isn't active yet.

Fixes #53 