### PR TITLE
update to gradle 4.10.1 or high

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -97,8 +97,8 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task "jar${name}"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        task "jar${name}"(type: Jar, dependsOn: variant.javaCompileProvider.get()) {
+            from variant.javaCompileProvider.get().destinationDir
         }
     }
 


### PR DESCRIPTION
Add suport to gradle 4.10.1 or high!
The new version of android studio 3.3 recommendete to update gradle project to 4.10.1 

> To take advantage of the latest features, improvements, and security fixes, we strongly recommend that you update the Android Gradle plugin to version 3.3.0 and Gradle to version 4.10.1. [Release notes ](https://developer.android.com/studio/releases/gradle-plugin) 

>Android plugin 3.2.0 and higher now support building the Android App Bundle—a new upload format that defers APK generation and signing to compatible app stores, such as Google Play. With app bundles, you no longer have to build, sign, and manage multiple APKs, and users get smaller, more optimized downloads. [Learn more](https://developer.android.com/guide/app-bundle/?utm_source=android-studio)

but if the upgrade to the new Android gradle warning come up, becouse  was obsoleted 

> WARNING: API 'variant.getJavaCompile()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'.

> It will be removed at the end of 2019.
> For more information, [see ](https://d.android.com/r/tools/task-configuration-avoidance.)
> To determine what is calling variant.getJavaCompile(), use -Pandroid.debug.obsoleteApi=true on the command line to display a stack trace.


Changelog:
----------
[Android] [Deprecated] - fix warinings obsolete to update to gradle 4.10.1 or high

Test Plan:
----------
change gradle-wrapper.proprerties:
`- distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip`
`+ distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip`

and in build.gradle

` - classpath 'com.android.tools.build:gradle:3.2.0'`
`+ classpath 'com.android.tools.build:gradle:3.3.0'`

for warnnings starts, use this change and fix the problem! =)
