### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Read usage guide depending on if you are [using Expo](#usage-in-expo-with-react-
 
 Screens support is built into [react-navigation](https://github.com/react-navigation/react-navigation) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) for all the different navigator types (stack, tab, drawer, etc). We plan on adding it to other navigators in near future.
 
-To enable react-navigationto use screens instead of plain RN Views for rendering screen views, follow the steps below:
+To configure react-navigation to use screens instead of plain RN Views for rendering screen views, follow the steps below:
 
 1. Add this library as a depedency to your project:
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Read usage guide depending on if you are [using Expo](#usage-in-expo-with-react-
 
 ## Usage with [react-navigation](https://github.com/react-navigation/react-navigation) (without Expo)
 
-Screens support is built into [stack navigator](https://reactnavigation.org/docs/en/stack-navigator.html) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) of [react-navigation](https://github.com/react-navigation/react-navigation). We plan on adding it to other navigators in near future.
+Screens support is built into [stack navigator](https://reactnavigation.org/docs/en/stack-navigator.html), [tab navigator](https://reactnavigation.org/docs/en/tab-navigator.html), and [drawer navigator](https://reactnavigation.org/docs/en/drawer-navigator.html) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) of [react-navigation](https://github.com/react-navigation/react-navigation). We plan on adding it to other navigators in near future.
 
 To enable stack navigator to use screens instead of plain RN Views for rendering stack cards follow the steps below:
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Read usage guide depending on if you are [using Expo](#usage-in-expo-with-react-
 
 ## Usage with [react-navigation](https://github.com/react-navigation/react-navigation) (without Expo)
 
-Screens support is built into [stack navigator](https://reactnavigation.org/docs/en/stack-navigator.html), [tab navigator](https://reactnavigation.org/docs/en/tab-navigator.html), and [drawer navigator](https://reactnavigation.org/docs/en/drawer-navigator.html) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) of [react-navigation](https://github.com/react-navigation/react-navigation). We plan on adding it to other navigators in near future.
+Screens support is built into [react-navigation](https://github.com/react-navigation/react-navigation) starting from version [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0) for all the different navigator types (stack, tab, drawer, etc). We plan on adding it to other navigators in near future.
 
-To enable stack navigator to use screens instead of plain RN Views for rendering stack cards follow the steps below:
+To enable react-navigationto use screens instead of plain RN Views for rendering screen views, follow the steps below:
 
 1. Add this library as a depedency to your project:
 ```


### PR DESCRIPTION
The docs do not state that react-native-screens is also used by default for the tab and drawer navigators. I updated the docs to include that. I didn't see support in any of the other navigators that I looked at, but if there are any others, we should update the documentation for them as well.