### PR TITLE
Fix non ascii character in comment

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -77,7 +77,7 @@ public class Screen extends ViewGroup implements ReactPointerEventsView {
 
   @Override
   public void setLayerType(int layerType, @Nullable Paint paint) {
-    // ignore – layer type is controlled by `transitioning` prop
+    // ignore - layer type is controlled by `transitioning` prop
   }
 
   public void setNeedsOffscreenAlphaCompositing(boolean needsOffscreenAlphaCompositing) {


### PR DESCRIPTION
I was getting the following compilation errors when I pulled in this repo.

```
error: unmappable character for encoding ASCII
```

The root cause seems to be the character below was not from the ASCII set.