### PR TITLE
fix Screen.java:80: error: unmappable character for encoding ASCII   …

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -77,7 +77,7 @@ public class Screen extends ViewGroup implements ReactPointerEventsView {
 
   @Override
   public void setLayerType(int layerType, @Nullable Paint paint) {
-    // ignore – layer type is controlled by `transitioning` prop
+    // ignore - layer type is controlled by `transitioning` prop
   }
 
   public void setNeedsOffscreenAlphaCompositing(boolean needsOffscreenAlphaCompositing) {


### PR DESCRIPTION
…  // ignore ??? layer type is controlled by `transitioning` prop

When building our app with Android studio we were always getting the following error:
> Task :react-native-screens:androidJavadoc FAILED
node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/Screen.java:80: error: unmappable character for encoding ASCII
    // ignore ??? layer type is controlled by `transitioning` prop
              ^
The file is encoded in UTF-8 - I don't know why the error talks about ASCII, but it also seems that the minus on that line is not a minus from the default charset?