### PR TITLE
Fix the missing setRef handler

### DIFF
--- a/src/screens.native.js
+++ b/src/screens.native.js
@@ -58,7 +58,7 @@ export class Screen extends React.Component {
 
       return <Animated.View {...props} ref={this.setRef} />;
     } else if (version.minor >= 57) {
-      return <AnimatedNativeScreen {...this.props} />;
+      return <AnimatedNativeScreen {...this.props} ref={this.setRef} />;
     } else {
       // On RN version below 0.57 we need to wrap screen's children with an
       // additional View because of a bug fixed in react-native/pull/20658 which


### PR DESCRIPTION
I was debugging why react-navigation-stack wasn't computing pointerEvents correctly. 
(https://github.com/react-navigation/react-navigation-
stack/blob/93470b4be8ab76558eda635069248ce1a74fe1d8/src/views/StackView/createPointerEventsContainer.js#L76)

Turns out (https://github.com/react-navigation/react-navigation-stack/blob/93470b4be8ab76558eda635069248ce1a74fe1d8/src/views/StackView/createPointerEventsContainer.js#L53) always bails as `this._component` is always null.

Turns out the callback passed to `<Screen>` is never called here (https://github.com/react-navigation/react-navigation-stack/blob/93470b4be8ab76558eda635069248ce1a74fe1d8/src/views/StackView/StackViewCard.js#L62)

This PR adds the missing ref if you're running RN version >= 0.57

With this change the callbacks are registered correctly (I tested ios only)

cc: @brentvatne for the downstream effects