### PR TITLE
Fix type of active prop in typescript definitions

### DIFF
--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -3,13 +3,13 @@
 
 declare module 'react-native-screens' {
   import { ComponentClass } from 'react';
-  import { ViewProps } from 'react-native';
+  import { ViewProps, Animated } from 'react-native';
 
   export function useScreens(shouldUseScreens?: boolean): void;
   export function screensEnabled(): boolean;
 
   export interface ScreenProps extends ViewProps {
-    active?: boolean;
+    active?: 0 | 1 | Animated.AnimatedInterpolation;
     onComponentRef?: (view: any) => void;
   }
   export const Screen: ComponentClass<ScreenProps>;


### PR DESCRIPTION
The TS definitions specify the prop as a boolean, but passing a boolean causes a crash.