### PR TITLE
Enhancement: change to useScreens to enableScreens

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -11,14 +11,14 @@ import {
   createSwitchNavigator,
   createAppContainer,
 } from 'react-navigation';
-import { useScreens } from 'react-native-screens';
+import { enableScreens } from 'react-native-screens';
 
 import Stack from './stack';
 import Tabs from './tabs';
 import Navigation from './navigation';
 import NavigationTabsAndStack from './navigationTabsAndStack';
 
-useScreens();
+enableScreens();
 
 const SCREENS = {
   Stack: { screen: Stack, title: 'Stack example' },

--- a/Example/navigationTabsAndStack.js
+++ b/Example/navigationTabsAndStack.js
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { Text, View, StyleSheet, Button } from 'react-native';
-import { useScreens } from 'react-native-screens';
+import { enableScreens } from 'react-native-screens';
 import {
   createAppContainer,
   createStackNavigator,
   createBottomTabNavigator,
 } from 'react-navigation';
 
-useScreens();
+enableScreens();
 
 class DetailsScreen extends React.Component {
   static navigationOptions = ({ navigation }) => {

--- a/README.md
+++ b/README.md
@@ -13,28 +13,32 @@ Screens support is built into [react-navigation](https://github.com/react-naviga
 
 To configure react-navigation to use screens instead of plain RN Views for rendering screen views, follow the steps below:
 
-1. Add this library as a depedency to your project:
-```
+1. Add this library as a dependency to your project:
+
+```bash
 yarn add react-native-screens
 ```
 
-2. Link native modules this library ships with into your app:
-```
+2.Link native modules this library ships with into your app:
+
+```bash
 react-native link react-native-screens
 ```
 
- > If you are not familiar with the concept of linking libraries [read on here](https://facebook.github.io/react-native/docs/linking-libraries-ios).
+> If you are not familiar with the concept of linking libraries [read on here](https://facebook.github.io/react-native/docs/linking-libraries-ios).
 
-3. Enable screens support before any of your navigation screen renders. Add the following code to your main application file (e.g. App.js):
+3.Enable screens support before any of your navigation screen renders. Add the following code to your main application file (e.g. App.js):
+
 ```js
-import { useScreens } from 'react-native-screens';
+import { enableScreens } from 'react-native-screens';
 
-useScreens();
+enableScreens();
 ```
 
 Note that the above code need to execute before first render of a navigation screen. You can check Example's app [App.js](https://github.com/kmagiera/react-native-screens/blob/master/Example/App.js#L16) file as a reference.
 
-4. On Android change your main activity class to extend [`ReactFragmentActivity`](https://github.com/facebook/react-native/blob/0.57-stable/ReactAndroid/src/main/java/com/facebook/react/ReactFragmentActivity.java). The file you'll have to change is likely called `MainActivity.java` unless you customized it after creating your project:
+4.On Android change your main activity class to extend [`ReactFragmentActivity`](https://github.com/facebook/react-native/blob/0.57-stable/ReactAndroid/src/main/java/com/facebook/react/ReactFragmentActivity.java). The file you'll have to change is likely called `MainActivity.java` unless you customized it after creating your project:
+
 ```diff
 -import com.facebook.react.ReactActivity;
 +import android.os.Bundle;
@@ -53,21 +57,23 @@ Note that the above code need to execute before first render of a navigation scr
      protected String getMainComponentName() {
 ```
 
-5. Make sure that the version of [react-navigation](https://github.com/react-navigation/react-navigation) you are using is 2.14.0 or higher
+5.Make sure that the version of [react-navigation](https://github.com/react-navigation/react-navigation) you are using is 2.14.0 or higher
 
-5. You are all set 🎉 – when screens are enabled in your application code react-navigation will automatically use them instead of relying on plain React Native Views.
+6.You are all set 🎉 – when screens are enabled in your application code react-navigation will automatically use them instead of relying on plain React Native Views.
 
 ## Usage in Expo with [react-navigation](https://github.com/react-navigation/react-navigation)
 
 Screens support is built into Expo [SDK 30](https://blog.expo.io/expo-sdk-30-0-0-is-now-available-e64d8b1db2a7) and react-navigation starting from [2.14.0](https://github.com/react-navigation/react-navigation/releases/tag/2.14.0). Make sure your app use these versions before you start.
 
 1. Add screens library as dependency to your project – you can skip this step when using snack as the dependency will be imported when you import it in one of the JS files
-```
+
+```bash
 yarn add react-native-screens
 ```
 
 2. Open your App.js file and add the following snippet somewhere near the top of the file (e.g. right after import statements):
-```
+
+```js
 import { useScreens } from 'react-native-screens';
 
 useScreens();
@@ -81,8 +87,7 @@ React-native-navigation library already uses native containers for rendering nav
 
 ## Interop with other libraries
 
-This library should work out of the box with all existing react-native libraries. If you expirience problems with interoperability please [report an issue](https://github.com/kmagiera/react-native-screens/issues).
-
+This library should work out of the box with all existing react-native libraries. If you experience problems with interoperability please [report an issue](https://github.com/kmagiera/react-native-screens/issues).
 
 ## Guide for navigation library authors
 
@@ -95,7 +100,7 @@ This component is a container for one or more `Screen` components.
 It does not accept other component types are direct children.
 The role of container is to control which of its children screens should be attached to the view hierarchy.
 It does that by monitoring `active` property of each of its children.
-It it possible to have as many `active` children as you'd like but in order for the component to be the most effictent we should keep the number of active screens to the minimum.
+It it possible to have as many `active` children as you'd like but in order for the component to be the most efficient we should keep the number of active screens to the minimum.
 In a case of stack navigator or tabs navigator we only want to have one active screen (the top most view on a stack or the selected tab).
 Then for the time of transitioning between views we may want to activate a second screen for the duration of transition, and then go back to just one active screen.
 
@@ -161,5 +166,5 @@ React native screens library is licensed under [The MIT License](LICENSE).
 
 This project is supported by amazing people from [Expo.io](https://expo.io) and [Software Mansion](https://swmansion.com)
 
-[![expo](https://avatars2.githubusercontent.com/u/12504344?v=3&s=100 "Expo.io")](https://expo.io)
-[![swm](https://avatars1.githubusercontent.com/u/6952717?v=3&s=100 "Software Mansion")](https://swmansion.com)
+[![expo](https://avatars2.githubusercontent.com/u/12504344?v=3&s=100 'Expo.io')](https://expo.io)
+[![swm](https://avatars1.githubusercontent.com/u/6952717?v=3&s=100 'Software Mansion')](https://swmansion.com)

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -5,7 +5,7 @@ declare module 'react-native-screens' {
   import { ComponentClass } from 'react';
   import { ViewProps } from 'react-native';
 
-  export function useScreens(shouldUseScreens?: boolean): void;
+  export function enableScreens(shouldEnableScreens?: boolean): void;
   export function screensEnabled(): boolean;
 
   export interface ScreenProps extends ViewProps {

--- a/src/screens.d.ts
+++ b/src/screens.d.ts
@@ -5,6 +5,7 @@ declare module 'react-native-screens' {
   import { ComponentClass } from 'react';
   import { ViewProps } from 'react-native';
 
+  export function useScreens(shouldUseScreens?: boolean): void;
   export function enableScreens(shouldEnableScreens?: boolean): void;
   export function screensEnabled(): boolean;
 

--- a/src/screens.native.js
+++ b/src/screens.native.js
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import { version } from 'react-native/Libraries/Core/ReactNativeVersion';
 
-let USE_SCREENS = false;
+let ENABLE_SCREENS = false;
 
 // UIManager[`${moduleName}`] is deprecated in RN 0.58 and `getViewManagerConfig` is added.
 // We can remove this when we drop support for RN < 0.58.
@@ -17,9 +17,9 @@ const getViewManagerConfigCompat = name =>
     ? UIManager.getViewManagerConfig(name)
     : UIManager[name];
 
-export function useScreens(shouldUseScreens = true) {
-  USE_SCREENS = shouldUseScreens;
-  if (USE_SCREENS && !getViewManagerConfigCompat('RNSScreen')) {
+export function enableScreens(shouldEnableScreens = true) {
+  ENABLE_SCREENS = shouldEnableScreens;
+  if (ENABLE_SCREENS && !getViewManagerConfigCompat('RNSScreen')) {
     console.error(
       `Screen native module hasn't been linked. Please check the react-native-screens README for more details`
     );
@@ -27,7 +27,7 @@ export function useScreens(shouldUseScreens = true) {
 }
 
 export function screensEnabled() {
-  return USE_SCREENS;
+  return ENABLE_SCREENS;
 }
 
 export const NativeScreen = requireNativeComponent('RNSScreen', null);
@@ -48,7 +48,7 @@ export class Screen extends React.Component {
     this.props.onComponentRef && this.props.onComponentRef(ref);
   };
   render() {
-    if (!USE_SCREENS) {
+    if (!ENABLE_SCREENS) {
       // Filter out active prop in this case because it is unused and
       // can cause problems depending on react-native version:
       // https://github.com/react-navigation/react-navigation/issues/4886
@@ -79,7 +79,7 @@ export class Screen extends React.Component {
 
 export class ScreenContainer extends React.Component {
   render() {
-    if (!USE_SCREENS) {
+    if (!ENABLE_SCREENS) {
       return <View {...this.props} />;
     } else {
       return <NativeScreenContainer {...this.props} />;

--- a/src/screens.native.js
+++ b/src/screens.native.js
@@ -26,6 +26,11 @@ export function enableScreens(shouldEnableScreens = true) {
   }
 }
 
+// we should remove this at some point
+export function useScreens(shouldUseScreens = true) {
+  enableScreens(shouldUseScreens);
+}
+
 export function screensEnabled() {
   return ENABLE_SCREENS;
 }

--- a/src/screens.web.js
+++ b/src/screens.web.js
@@ -2,19 +2,19 @@ import debounce from 'debounce';
 import React from 'react';
 import { Animated, View } from 'react-native';
 
-let _shouldUseScreens = true;
+let _shouldEnableScreens = true;
 
-export function useScreens(shouldUseScreens = true) {
-  if (shouldUseScreens) {
+export function enableScreens(shouldEnableScreens = true) {
+  if (shouldEnableScreens) {
     console.warn(
       'react-native-screens is not fully supported on this platform yet.'
     );
   }
-  _shouldUseScreens = shouldUseScreens;
+  _shouldEnableScreens = shouldEnableScreens;
 }
 
 export function screensEnabled() {
-  return _shouldUseScreens;
+  return _shouldEnableScreens;
 }
 
 function isAnimatedValue(value) {


### PR DESCRIPTION
This wants to be a small PR to improve the usability of the library, based on this conversation: https://twitter.com/grifotv/status/1127847192067215360.

Since the release of RNS there has been a new major player in the React game: hooks. And sadly `useScreens` recalls too closely Hooks, and this can lead to misunderstanding.

Changing it to `enableScreens` will make the difference clear, but at the same time it will be a BREAKING CHANGE for everyone using the lib.

So if we prefer to keep it around as useScreens I'm ok with it too, and we can close this.

Also, I did some tweaks to the README + fix some typos.