### PR TITLE
Fix issue with soft keyboard not showing from time to time on Android

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -8,8 +8,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.swmansion.rnscreens.Screen.StackAnimation.*;
-
 public class ScreenStack extends ScreenContainer {
 
   private final ArrayList<Screen> mStack = new ArrayList<>();


### PR DESCRIPTION
This PR fixes a problem with soft keyboard not always popping up when new screen is shown with an autoFocus inputtext.

The root cause is the mechanism used by autoFocus flag that uses `requestAnimationFrame` in which focus is called on a textinput component ref. Because of that RN may sometimes evaluate focus handler while the native view is not yet attached to view hierarchy. As a result InputMethodManager RN use to trigger soft keyboard may fail seeing a non attached input field. In this workaround we listed to onAttach events on screens and look for focused fields. If there is one it means the field has been focused before the transition ended. In that case we use `OnAttachStateChangeListener` that we plug to the textinput waiting for it to attach. The listener then triggers soft input keyboard.