### PR TITLE
Implement full screen modals on iOS

### DIFF
--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -9,6 +9,8 @@ typedef NS_ENUM(NSInteger, RNSScreenStackPresentation) {
   RNSScreenStackPresentationPush,
   RNSScreenStackPresentationModal,
   RNSScreenStackPresentationTransparentModal,
+  RNSScreenStackPresentationContainedModal,
+  RNSScreenStackPresentationContainedTransparentModal
 };
 
 typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
@@ -27,7 +29,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
 @interface RNSScreenManager : RCTViewManager
 @end
 
-@interface RNSScreenView : RCTView <RCTInvalidating>
+@interface RNSScreenView : RCTView
 
 @property (nonatomic, copy) RCTDirectEventBlock onDismissed;
 @property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;

--- a/ios/RNSScreenStack.h
+++ b/ios/RNSScreenStack.h
@@ -9,6 +9,6 @@
 
 @end
 
-@interface RNSScreenStackManager : RCTViewManager
+@interface RNSScreenStackManager : RCTViewManager <RCTInvalidating>
 
 @end


### PR DESCRIPTION
On iOS by default modals show up in full-screen mode. This behavior can be customized and instead of mouting new screens in top level window they can be mounted under a given UINavController. We used to be relying on that behavior (see "CurrentContext" presentation mode). This, apparently wasn't matching the default functionality of the OS. This change is adding it as a default and keeping the old way under newly exposed presentation modes: containedModal and containedTransparentModal

Thanks to this change, iOS 13 modals can work properly.

Android support for the newly added presentation types is missing and will be added in follow up PR.