### PR TITLE
Fix header config when navigating back gets cancelled.

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -2,6 +2,7 @@
 
 #import "RNSScreen.h"
 #import "RNSScreenContainer.h"
+#import "RNSScreenStackHeaderConfig.h"
 
 #import <React/RCTUIManager.h>
 #import <React/RCTShadowView.h>
@@ -125,6 +126,13 @@
 - (UIView *)reactSuperview
 {
   return _reactSuperview;
+}
+
+- (void)addSubview:(UIView *)view
+{
+  if (![view isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
+    [super addSubview:view];
+  }
 }
 
 - (void)notifyFinishTransitioning

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -42,12 +42,14 @@
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
   UIView *view = viewController.view;
+  RNSScreenStackHeaderConfig *config = nil;
   for (UIView *subview in view.reactSubviews) {
     if ([subview isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
-      [((RNSScreenStackHeaderConfig*) subview) willShowViewController:viewController];
+      config = (RNSScreenStackHeaderConfig*) subview;
       break;
     }
   }
+  [RNSScreenStackHeaderConfig willShowViewController:viewController withConfig:config];
 }
 
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -19,7 +19,7 @@
 @property (nonatomic) BOOL translucent;
 @property (nonatomic) BOOL gestureEnabled;
 
-- (void)willShowViewController:(UIViewController *)vc;
++ (void)willShowViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig*)config;
 
 @end
 


### PR DESCRIPTION
This change fixes the problem when header would update to the previous screen configuration as a result of starting swipe back gesture but never restore to the original one in case swipe back gets cancelled (e.g. user didn't swipe far enough). The problem was that as a result of swipe back we'd apply header config changes but after cancel there was no trigger to reset header to the previous state.