### PR TITLE
Set PointerEvents in auto mode (regardless of mTransitioning value)

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -154,7 +154,7 @@ public class Screen extends ViewGroup implements ReactPointerEventsView {
 
   @Override
   public PointerEvents getPointerEvents() {
-    return mTransitioning ? PointerEvents.NONE : PointerEvents.AUTO;
+    return /* mTransitioning ? PointerEvents.NONE : */ PointerEvents.AUTO;
   }
 
   @Override


### PR DESCRIPTION
Caused by disabled touch events on android devices (using of `createNativeStackNavigator` breaks navigation logic if `transparentCard: true` option used)
