### PR TITLE
Call update bounds after transition on iOS

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -240,6 +240,10 @@
   }
 }
 
+- (void) viewDidAppear:(BOOL)animated {
+  [((RNSScreenView *)self.view) updateBounds];
+}
+
 - (void)notifyFinishTransitioning
 {
   [_previousFirstResponder becomeFirstResponder];


### PR DESCRIPTION
We observe that bounds are not updating at all. Method `updateBounds` is not called at all while transitioning.

As a result yoga reevaluation is not performed so content has bad size i.e. it's not possible to scroll to the very end in ScrollView because a component has a bad size in comparison to the parent (it should have the exact same height).   

It can be observed in navigation-ex and it works better after my fix: https://streamable.com/miun2