### PR TITLE
Fix header rendering – layout and transparency

### DIFF
--- a/Example/android/app/src/main/AndroidManifest.xml
+++ b/Example/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:networkSecurityConfig="@xml/network_security_config"
+      android:usesCleartextTraffic="true"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
       <activity

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,9 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
 }
 
 def configureReactNativePom(def pom) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenFragment.java
@@ -1,0 +1,50 @@
+package com.swmansion.rnscreens;
+
+import android.annotation.SuppressLint;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.events.EventDispatcher;
+
+public class ScreenFragment extends Fragment {
+
+  protected Screen mScreenView;
+
+  public ScreenFragment() {
+    throw new IllegalStateException("Screen fragments should never be restored");
+  }
+
+  @SuppressLint("ValidFragment")
+  public ScreenFragment(Screen screenView) {
+    super();
+    mScreenView = screenView;
+  }
+
+  @Override
+  public View onCreateView(LayoutInflater inflater,
+                           @Nullable ViewGroup container,
+                           @Nullable Bundle savedInstanceState) {
+    return mScreenView;
+  }
+
+  public Screen getScreen() {
+    return mScreenView;
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+    ((ReactContext) mScreenView.getContext())
+            .getNativeModule(UIManagerModule.class)
+            .getEventDispatcher()
+            .dispatchEvent(new ScreenDismissedEvent(mScreenView.getId()));
+  }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -8,40 +8,74 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ScreenStack extends ScreenContainer {
+public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
 
-  private final ArrayList<Screen> mStack = new ArrayList<>();
-  private final Set<Screen> mDismissed = new HashSet<>();
+  private final ArrayList<ScreenStackFragment> mStack = new ArrayList<>();
+  private final Set<ScreenStackFragment> mDismissed = new HashSet<>();
 
-  private Screen mTopScreen = null;
+  private ScreenStackFragment mTopScreen = null;
+  private boolean mLayoutEnqueued = false;
 
   public ScreenStack(Context context) {
     super(context);
   }
 
-  public void dismiss(Screen screen) {
-    mDismissed.add(screen);
+  public void dismiss(ScreenStackFragment screenFragment) {
+    mDismissed.add(screenFragment);
     onUpdate();
-  }
-
-  public Screen getTopScreen() {
-    for (int i = getScreenCount() - 1; i >= 0; i--) {
-      Screen screen = getScreenAt(i);
-      if (!mDismissed.contains(screen)) {
-        return screen;
-      }
-    }
-    throw new IllegalStateException("Stack is empty");
   }
 
   public Screen getRootScreen() {
     for (int i = 0, size = getScreenCount(); i < size; i++) {
       Screen screen = getScreenAt(i);
-      if (!mDismissed.contains(screen)) {
+      if (!mDismissed.contains(screen.getFragment())) {
         return screen;
       }
     }
     throw new IllegalStateException("Stack has no root screen set");
+  }
+
+  @Override
+  protected ScreenStackFragment adapt(Screen screen) {
+    return new ScreenStackFragment(screen);
+  }
+
+  @Override
+  protected void onLayout(boolean changed, int l, int t, int r, int b) {
+    for (int i = 0, size = getChildCount(); i < size; i++) {
+      getChildAt(i).layout(0, 0, getWidth(), getHeight());
+    }
+  }
+
+  @Override
+  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+    for (int i = 0, size = getChildCount(); i < size; i++) {
+      getChildAt(i).measure(
+              MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+              MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+    }
+  }
+
+  private final Runnable mLayoutRunnable = new Runnable() {
+    @Override
+    public void run() {
+      mLayoutEnqueued = false;
+      measure(
+              MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+              MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+      layout(getLeft(), getTop(), getRight(), getBottom());
+    }
+  };
+
+  @Override
+  public void requestLayout() {
+    super.requestLayout();
+
+    if (!mLayoutEnqueued) {
+      mLayoutEnqueued = true;
+      post(mLayoutRunnable);
+    }
   }
 
   @Override
@@ -54,20 +88,20 @@ public class ScreenStack extends ScreenContainer {
   @Override
   protected void onUpdate() {
     // remove all screens previously on stack
-    for (Screen screen : mStack) {
-      if (!mScreens.contains(screen) || mDismissed.contains(screen)) {
-        getOrCreateTransaction().remove(screen.getFragment());
+    for (ScreenStackFragment screen : mStack) {
+      if (!mScreenFragments.contains(screen) || mDismissed.contains(screen)) {
+        getOrCreateTransaction().remove(screen);
       }
     }
-    Screen newTop = null;
-    Screen belowTop = null; // this is only set if newTop has TRANSPARENT_MODAL presentation mode
+    ScreenStackFragment newTop = null;
+    ScreenStackFragment belowTop = null; // this is only set if newTop has TRANSPARENT_MODAL presentation mode
 
-    for (int i = mScreens.size() - 1; i >= 0; i--) {
-      Screen screen = mScreens.get(i);
+    for (int i = mScreenFragments.size() - 1; i >= 0; i--) {
+      ScreenStackFragment screen = mScreenFragments.get(i);
       if (!mDismissed.contains(screen)) {
         if (newTop == null) {
           newTop = screen;
-          if (newTop.getStackPresentation() != Screen.StackPresentation.TRANSPARENT_MODAL) {
+          if (newTop.getScreen().getStackPresentation() != Screen.StackPresentation.TRANSPARENT_MODAL) {
             break;
           }
         } else {
@@ -78,34 +112,34 @@ public class ScreenStack extends ScreenContainer {
     }
 
 
-    for (Screen screen : mScreens) {
+    for (ScreenStackFragment screen : mScreenFragments) {
       // add all new views that weren't on stack before
       if (!mStack.contains(screen) && !mDismissed.contains(screen)) {
-        getOrCreateTransaction().add(getId(), screen.getFragment());
+        getOrCreateTransaction().add(getId(), screen);
       }
       // detach all screens that should not be visible
       if (screen != newTop && screen != belowTop && !mDismissed.contains(screen)) {
-        getOrCreateTransaction().hide(screen.getFragment());
+        getOrCreateTransaction().hide(screen);
       }
     }
     // attach "below top" screen if set
     if (belowTop != null) {
-      final Screen top = newTop;
-      getOrCreateTransaction().show(belowTop.getFragment()).runOnCommit(new Runnable() {
+      final ScreenStackFragment top = newTop;
+      getOrCreateTransaction().show(belowTop).runOnCommit(new Runnable() {
         @Override
         public void run() {
-          top.bringToFront();
+          top.getScreen().bringToFront();
         }
       });
     }
-    getOrCreateTransaction().show(newTop.getFragment());
+    getOrCreateTransaction().show(newTop);
 
     if (!mStack.contains(newTop)) {
       // if new top screen wasn't on stack we do "open animation" so long it is not the very first screen on stack
       if (mTopScreen != null) {
         // there was some other screen attached before
         int transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN;
-        switch (mTopScreen.getStackAnimation()) {
+        switch (mTopScreen.getScreen().getStackAnimation()) {
           case NONE:
             transition = FragmentTransaction.TRANSIT_NONE;
             break;
@@ -118,7 +152,7 @@ public class ScreenStack extends ScreenContainer {
     } else if (mTopScreen != null && !mTopScreen.equals(newTop)) {
       // otherwise if we are performing top screen change we do "back animation"
       int transition = FragmentTransaction.TRANSIT_FRAGMENT_CLOSE;
-      switch (mTopScreen.getStackAnimation()) {
+      switch (mTopScreen.getScreen().getStackAnimation()) {
         case NONE:
           transition = FragmentTransaction.TRANSIT_NONE;
           break;
@@ -132,7 +166,7 @@ public class ScreenStack extends ScreenContainer {
     mTopScreen = newTop;
 
     mStack.clear();
-    mStack.addAll(mScreens);
+    mStack.addAll(mScreenFragments);
 
     tryCommitTransaction();
   }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -1,0 +1,82 @@
+package com.swmansion.rnscreens;
+
+import android.annotation.SuppressLint;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+import com.facebook.react.uimanager.PixelUtil;
+import com.google.android.material.appbar.AppBarLayout;
+
+public class ScreenStackFragment extends ScreenFragment {
+
+  private static final float TOOLBAR_ELEVATION = PixelUtil.toPixelFromDIP(4);
+
+  private AppBarLayout mAppBarLayout;
+  private Toolbar mToolbar;
+  private boolean mShadowHidden;
+
+  @SuppressLint("ValidFragment")
+  public ScreenStackFragment(Screen screenView) {
+    super(screenView);
+  }
+
+  public void removeToolbar() {
+    if (mAppBarLayout != null) {
+      ((CoordinatorLayout) getView()).removeView(mAppBarLayout);
+    }
+  }
+
+  public void setToolbar(Toolbar toolbar) {
+    if (mAppBarLayout != null) {
+      mAppBarLayout.addView(toolbar);
+    }
+    mToolbar = toolbar;
+    AppBarLayout.LayoutParams params = new AppBarLayout.LayoutParams(
+            AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT);
+    params.setScrollFlags(0);
+    mToolbar.setLayoutParams(params);
+  }
+
+  public void setToolbarShadowHidden(boolean hidden) {
+    if (mShadowHidden != hidden) {
+      mAppBarLayout.setTargetElevation(hidden ? 0 : TOOLBAR_ELEVATION);
+      mShadowHidden = hidden;
+    }
+  }
+
+  @Override
+  public View onCreateView(LayoutInflater inflater,
+                           @Nullable ViewGroup container,
+                           @Nullable Bundle savedInstanceState) {
+    CoordinatorLayout view = new CoordinatorLayout(getContext());
+    CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
+    params.setBehavior(new AppBarLayout.ScrollingViewBehavior());
+    mScreenView.setLayoutParams(params);
+    view.addView(mScreenView);
+
+    mAppBarLayout = new AppBarLayout(getContext());
+    // By default AppBarLayout will have a background color set but since we cover the whole layout
+    // with toolbar (that can be semi-transparent) the bar layout background color does not pay a
+    // role. On top of that it breaks screens animations when alfa offscreen compositing is off
+    // (which is the default)
+    mAppBarLayout.setBackgroundColor(Color.TRANSPARENT);
+    mAppBarLayout.setLayoutParams(new AppBarLayout.LayoutParams(
+            AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT));
+    view.addView(mAppBarLayout);
+
+    if (mToolbar != null) {
+      mAppBarLayout.addView(mToolbar);
+    }
+
+    return view;
+  }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackViewManager.java
@@ -59,4 +59,9 @@ public class ScreenStackViewManager extends ViewGroupManager<ScreenStack> {
   public View getChildAt(ScreenStack parent, int index) {
     return parent.getScreenAt(index);
   }
+
+  @Override
+  public boolean needsCustomLayoutForChildren() {
+    return true;
+  }
 }


### PR DESCRIPTION
Fixes to most of the issues listed in #153 – thanks @ferrannp for trying out native stack and for reporting these.

This PR fixes the issue when screen rendered under ScreenStack container would use invalid dimensions for layouting its children. On iOS we move the control over the size of that component to `UINavController` subclass which reports screen size back to RN's UIManager to let yoga layout subviews.

On Android we introduced an intermediate view hierarchy for each screen that uses `CoordinatorLayout` and `AppBarLayout`. We are not fully utilizing the power of these two native components and for now only rely on them to layout navbar and screen container. Similarity to iOS we then pass measured screen dimensions to yoga in order for react native to render children properly. 
