### PR TITLE
Fix non-default modal presentation styles

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -117,7 +117,7 @@
   }
   // `modalPresentationStyle` must be set before accessing `presentationController`
   // otherwise a default controller will be created and cannot be changed after.
-  // Docuemented here: https://developer.apple.com/documentation/uikit/uiviewcontroller/1621426-presentationcontroller?language=objc
+  // Documented here: https://developer.apple.com/documentation/uikit/uiviewcontroller/1621426-presentationcontroller?language=objc
   _controller.presentationController.delegate = self;
 }
 

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -58,7 +58,6 @@
   if (self = [super init]) {
     _bridge = bridge;
     _controller = [[RNSScreen alloc] initWithView:self];
-    _controller.presentationController.delegate = self;
     _stackPresentation = RNSScreenStackPresentationPush;
     _stackAnimation = RNSScreenStackAnimationDefault;
   }
@@ -116,6 +115,10 @@
       _controller.modalPresentationStyle = UIModalPresentationOverCurrentContext;
       break;
   }
+  // `modalPresentationStyle` must be set before accessing `presentationController`
+  // otherwise a default controller will be created and cannot be changed after.
+  // Docuemented here: https://developer.apple.com/documentation/uikit/uiviewcontroller/1621426-presentationcontroller?language=objc
+  _controller.presentationController.delegate = self;
 }
 
 - (UIView *)reactSuperview


### PR DESCRIPTION
Using alternative modal presentation styles like `transparentModal` is not working. This is because accessing `presentationController` before setting the `modalPresentationStyle` causes the presentation controller to be created and cannot be changed afterwards. This is documented https://developer.apple.com/documentation/uikit/uiviewcontroller/1621426-presentationcontroller?language=objc.

Yes very cool API

Tested via @react-navigation/native-stack using presentation: 'transparentModal'.