### PR TITLE
Support fade in animation for modals on iOS

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -118,6 +118,21 @@
   }
 }
 
+- (void)setStackAnimation:(RNSScreenStackAnimation)stackAnimation
+{
+  _stackAnimation = stackAnimation;
+
+  switch (stackAnimation) {
+    case RNSScreenStackAnimationFade:
+      _controller.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
+      break;
+    case RNSScreenStackAnimationNone:
+    case RNSScreenStackAnimationDefault:
+      // Default
+      break;
+  }
+}
+
 - (UIView *)reactSuperview
 {
   return _reactSuperview;


### PR DESCRIPTION
Supporting fade in for modals can be done by using `modalTransitionStyle = UIModalTransitionStyleCrossDissolve`. For other type of animations we leave this as the default value.

Tested via `@react-navigation/native-stack` with `{ animation: 'fade', presentation: 'transparentModal' }`