### PR TITLE
Fix useScreens -> enableScreens renaming

### DIFF
--- a/src/screens.native.js
+++ b/src/screens.native.js
@@ -28,6 +28,7 @@ export function enableScreens(shouldEnableScreens = true) {
 
 // we should remove this at some point
 export function useScreens(shouldUseScreens = true) {
+  console.warn('Method `useScreens` is deprecated, please use `enableScreens`');
   enableScreens(shouldUseScreens);
 }
 
@@ -201,6 +202,7 @@ module.exports = {
   ScreenStackHeaderTitleView,
   ScreenStackHeaderCenterView,
 
+  enableScreens,
   useScreens,
   screensEnabled,
 };


### PR DESCRIPTION
There was a bug in PR that introduces enableScreens method to replace useScreens. The bug was that the method did not end up being exported (we use module.exports and not export syntax). On top of that I'm adding a deprecation warning to useScreens method as it interferes with some react hooks tooling.