### PR TITLE
Android native stack bugfixes.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -2,7 +2,6 @@ package com.swmansion.rnscreens;
 
 import android.content.Context;
 import android.graphics.Paint;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
@@ -13,7 +12,6 @@ import androidx.fragment.app.Fragment;
 
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.uimanager.MeasureSpecAssertions;
 import com.facebook.react.uimanager.PointerEvents;
 import com.facebook.react.uimanager.ReactPointerEventsView;
 import com.facebook.react.uimanager.UIManagerModule;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -25,6 +25,10 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
     onUpdate();
   }
 
+  public Screen getTopScreen() {
+    return mTopScreen.getScreen();
+  }
+
   public Screen getRootScreen() {
     for (int i = 0, size = getScreenCount(); i < size; i++) {
       Screen screen = getScreenAt(i);
@@ -51,9 +55,7 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
     super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     for (int i = 0, size = getChildCount(); i < size; i++) {
-      getChildAt(i).measure(
-              MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-              MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+      getChildAt(i).measure(widthMeasureSpec, heightMeasureSpec);
     }
   }
 
@@ -169,5 +171,9 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
     mStack.addAll(mScreenFragments);
 
     tryCommitTransaction();
+
+    for (ScreenStackFragment screen : mStack) {
+      screen.onStackUpdate();
+    }
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -52,6 +52,13 @@ public class ScreenStackFragment extends ScreenFragment {
     }
   }
 
+  public void onStackUpdate() {
+    View child = mScreenView.getChildAt(0);
+    if (child instanceof ScreenStackHeaderConfig) {
+      ((ScreenStackHeaderConfig) child).onUpdate();
+    }
+  }
+
   @Override
   public View onCreateView(LayoutInflater inflater,
                            @Nullable ViewGroup container,

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -82,6 +82,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setHideShadow(hideShadow);
   }
 
+  @ReactProp(name = "gestureEnabled", defaultBoolean = true)
+  public void setGestureEnabled(ScreenStackHeaderConfig config, boolean gestureEnabled) {
+    config.setGestureEnabled(gestureEnabled);
+  }
+
   @ReactProp(name = "hideBackButton")
   public void setHideBackButton(ScreenStackHeaderConfig config, boolean hideBackButton) {
     config.setHideBackButton(hideBackButton);

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -35,9 +35,11 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
   public void setStackPresentation(Screen view, String presentation) {
     if ("push".equals(presentation)) {
       view.setStackPresentation(Screen.StackPresentation.PUSH);
-    } else if ("modal".equals(presentation)) {
+    } else if ("modal".equals(presentation) || "containedModal".equals(presentation)) {
+      // at the moment Android implementation does not handle contained vs regular modals
       view.setStackPresentation(Screen.StackPresentation.MODAL);
-    } else if ("transparentModal".equals(presentation)) {
+    } else if ("transparentModal".equals(presentation) || "containedTransparentModal".equals((presentation))) {
+      // at the moment Android implementation does not handle contained vs regular modals
       view.setStackPresentation(Screen.StackPresentation.TRANSPARENT_MODAL);
     } else {
       throw new JSApplicationIllegalArgumentException("Unknown presentation type " + presentation);


### PR DESCRIPTION
A few bugs fixed with android native stack in this commit:
 - fixed a problem with views not resizing when keyboard appears, the bug was due to onMeasure forwardin getHeight which was the old height of the container instead of the changed one
 - fixed a problem with back button behavior not being consistent. Now back button is controlled by 'gestureEnabled' to emulate iOS behavior where there is no hw back button but you can swipe back instead.
 - added compatibility for "contained" modal styles - for now we always render "containted" fragments on Android, plan to add a way to render in dialogs in the future