### PR TITLE
Remove es exports from screens.native.js

### DIFF
--- a/src/screens.native.js
+++ b/src/screens.native.js
@@ -17,7 +17,7 @@ const getViewManagerConfigCompat = name =>
     ? UIManager.getViewManagerConfig(name)
     : UIManager[name];
 
-export function enableScreens(shouldEnableScreens = true) {
+function enableScreens(shouldEnableScreens = true) {
   ENABLE_SCREENS = shouldEnableScreens;
   if (ENABLE_SCREENS && !getViewManagerConfigCompat('RNSScreen')) {
     console.error(
@@ -27,12 +27,12 @@ export function enableScreens(shouldEnableScreens = true) {
 }
 
 // we should remove this at some point
-export function useScreens(shouldUseScreens = true) {
+function useScreens(shouldUseScreens = true) {
   console.warn('Method `useScreens` is deprecated, please use `enableScreens`');
   enableScreens(shouldUseScreens);
 }
 
-export function screensEnabled() {
+function screensEnabled() {
   return ENABLE_SCREENS;
 }
 


### PR DESCRIPTION
Follow up of 4749405d641c11c0bf5a6193f75ec15552217d69, let's remove the es exports from this file to avoid confusion. It uses `module.export`.