### PR TITLE
Fix iOS version runtime checks in RNSScreenStackHeaderConfig

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -107,8 +107,11 @@
     [navbar setTitleTextAttributes:attrs];
   }
   
-  if (@available(iOS 11.0, *) && config.largeTitle) {
-    if (config.largeTitleFontFamily || config.largeTitleFontSize || config.titleColor) {
+  if (@available(iOS 11.0, *)) {
+    if (
+      config.largeTitle &&
+      (config.largeTitleFontFamily || config.largeTitleFontSize || config.titleColor)
+    ) {
       NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
       if (config.titleColor) {
         largeAttrs[NSForegroundColorAttributeName] = config.titleColor;
@@ -149,7 +152,9 @@
   [navctr setNavigationBarHidden:shouldHide animated:YES];
   navctr.interactivePopGestureRecognizer.enabled = config.gestureEnabled;
 #ifdef __IPHONE_13_0
-  vc.modalInPresentation = !config.gestureEnabled;
+  if (@available(iOS 13.0, *)) {
+    vc.modalInPresentation = !config.gestureEnabled;
+  }
 #endif
   if (shouldHide) {
     return;


### PR DESCRIPTION
- `@available` should not be used with other conditions (not sure if it breaks anything but it does trigger warnings in xcode)
- missing runtime check before using `modalInPresentation`, kept the precompiler instruction so it still builds on older xcodes.