### PR TITLE
Use fragment manager back stack to handle hw back button presses on Android.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -7,6 +7,7 @@ import android.view.ViewParent;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
 import com.facebook.react.ReactRootView;
@@ -109,9 +110,13 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     return (FragmentActivity) context;
   }
 
+  protected FragmentManager getFragmentManager() {
+    return findRootFragmentActivity().getSupportFragmentManager();
+  }
+
   protected FragmentTransaction getOrCreateTransaction() {
     if (mCurrentTransaction == null) {
-      mCurrentTransaction = findRootFragmentActivity().getSupportFragmentManager().beginTransaction();
+      mCurrentTransaction = getFragmentManager().beginTransaction();
       mCurrentTransaction.setReorderingAllowed(true);
     }
     return mCurrentTransaction;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -86,4 +86,12 @@ public class ScreenStackFragment extends ScreenFragment {
 
     return view;
   }
+
+  public boolean isDismissable() {
+    View child = mScreenView.getChildAt(0);
+    if (child instanceof ScreenStackHeaderConfig) {
+      return ((ScreenStackHeaderConfig) child).isDismissable();
+    }
+    return true;
+  }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -10,7 +10,6 @@ import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.widget.TextView;
 
-import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
@@ -35,18 +34,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private final Toolbar mToolbar;
 
   private boolean mIsAttachedToWindow = false;
-
-  private OnBackPressedCallback mBackCallback = new OnBackPressedCallback(false) {
-    @Override
-    public void handleOnBackPressed() {
-      ScreenStack stack = getScreenStack();
-      Screen current = getScreen();
-      if (stack.getTopScreen() == current) {
-        stack.dismiss(getScreenFragment());
-      }
-      mBackCallback.remove();
-    }
-  };
 
   private OnClickListener mBackClickListener = new OnClickListener() {
     @Override
@@ -116,25 +103,18 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     return null;
   }
 
+  public boolean isDismissable() {
+    return mGestureEnabled;
+  }
+
   public void onUpdate() {
     Screen parent = (Screen) getParent();
     final ScreenStack stack = getScreenStack();
     boolean isRoot = stack == null ? true : stack.getRootScreen() == parent;
     boolean isTop = stack == null ? true : stack.getTopScreen() == parent;
 
-    // we need to clean up back handler especially in the case given screen is no longer on top
-    // because we don't want it to capture back event if it is not responsible for handling it
-    // as that would block other handlers from running
-    mBackCallback.remove();
-
     if (!mIsAttachedToWindow || !isTop) {
       return;
-    }
-
-    if (!isRoot && isTop && mGestureEnabled) {
-      Fragment fragment = getScreenFragment();
-      fragment.requireActivity().getOnBackPressedDispatcher().addCallback(fragment, mBackCallback);
-      mBackCallback.setEnabled(true);
     }
 
     if (mIsHidden) {


### PR DESCRIPTION
Before this change we'd rely on new androidx OnBackPressedCallback mechanism. It turns out not to work well in a few cases. The biggest problem with it was that when registered it'd never allow for the hw back button press to fallback to a system default behaviour and instead would always "still" that event. After several attempts of trying to make it work I decided to revert back to a FragmentManager's default solution.

This change adds an ability to use FragmentManager's back stack API. There are also a few problems with it we need to workaround though. One of the problem is the fact that we can not modify back stack history. What we do because of that is that we try to keep at most one item on the back stack and reset it each time our native stack updates. In order for that to work we create a fake transaction that hides and shows the same screen that displays on top. Thanks to that when hw back is pressed the built in transaction rollback logic does nothing to the UI and allows us to handle back navigation using back stack change listener.