### PR TITLE
Fix screen container layout on Android.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainerViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainerViewManager.java
@@ -43,4 +43,9 @@ public class ScreenContainerViewManager extends ViewGroupManager<ScreenContainer
   public View getChildAt(ScreenContainer parent, int index) {
     return parent.getScreenAt(index);
   }
+
+  @Override
+  public boolean needsCustomLayoutForChildren() {
+    return true;
+  }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -17,7 +17,6 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   private final Set<ScreenStackFragment> mDismissed = new HashSet<>();
 
   private ScreenStackFragment mTopScreen = null;
-  private boolean mLayoutEnqueued = false;
 
   private final FragmentManager.OnBackStackChangedListener mBackStackListener = new FragmentManager.OnBackStackChangedListener() {
     @Override
@@ -60,45 +59,9 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   }
 
   @Override
-  protected void onLayout(boolean changed, int l, int t, int r, int b) {
-    for (int i = 0, size = getChildCount(); i < size; i++) {
-      getChildAt(i).layout(0, 0, getWidth(), getHeight());
-    }
-  }
-
-  @Override
-  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-    super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-    for (int i = 0, size = getChildCount(); i < size; i++) {
-      getChildAt(i).measure(widthMeasureSpec, heightMeasureSpec);
-    }
-  }
-
-  @Override
   protected void onDetachedFromWindow() {
     super.onDetachedFromWindow();
     getFragmentManager().removeOnBackStackChangedListener(mBackStackListener);
-  }
-
-  private final Runnable mLayoutRunnable = new Runnable() {
-    @Override
-    public void run() {
-      mLayoutEnqueued = false;
-      measure(
-              MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-              MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
-      layout(getLeft(), getTop(), getRight(), getBottom());
-    }
-  };
-
-  @Override
-  public void requestLayout() {
-    super.requestLayout();
-
-    if (!mLayoutEnqueued) {
-      mLayoutEnqueued = true;
-      post(mLayoutRunnable);
-    }
   }
 
   @Override


### PR DESCRIPTION
This is a similar fix to the one already merged in #215 but for Android this time. We change default screen container to layout its direct children without using flexbox. This is to follow the same pattern as with native stack container.