### PR TITLE
Fix iOS stack navigator restoring state.

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -185,7 +185,7 @@
 
   if (firstTimePush) {
     // nothing pushed yet
-    [_controller setViewControllers:@[top] animated:NO];
+    [_controller setViewControllers:controllers animated:NO];
   } else if (top != lastTop) {
     if (![controllers containsObject:lastTop]) {
       // last top controller is no longer on stack


### PR DESCRIPTION
When more than one screen is initially mounted we were only installing the top navigator with UINavController. This was cauing the back-handling logic to not work properly.