### PR TITLE
Fix issue with stack triggering back on reload on Android.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -62,6 +62,15 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   protected void onDetachedFromWindow() {
     super.onDetachedFromWindow();
     getFragmentManager().removeOnBackStackChangedListener(mBackStackListener);
+    getFragmentManager().popBackStack(BACK_STACK_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+  }
+
+  @Override
+  protected void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    if (mTopScreen != null) {
+      setupBackHandlerIfNeeded(mTopScreen);
+    }
   }
 
   @Override
@@ -194,13 +203,13 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
       }
     }
     if (topScreen != firstScreen && topScreen.isDismissable()) {
-      getFragmentManager().addOnBackStackChangedListener(mBackStackListener);
       getFragmentManager()
               .beginTransaction()
               .hide(topScreen)
               .show(topScreen)
               .addToBackStack(BACK_STACK_TAG)
-              .commit();
+              .commitAllowingStateLoss();
+      getFragmentManager().addOnBackStackChangedListener(mBackStackListener);
     }
   }
 }


### PR DESCRIPTION
There was an issue with back stack listener being triggered after reload caused by the fact we weren't cleaning up stack manager's back stack on reload. As a result after reload listener would get triggered with and empty stack first and only then with a back stack with 1 item. Consequence of the first trigger was that we'd call dismiss and move back from the top screen which wasn't a desirable behavior.