### PR TITLE
Remove console.warn's (possibly leftover from debugging)

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -113,4 +113,6 @@ const styles = StyleSheet.create({
   },
 });
 
-export default createAppContainer(ExampleApp);
+// export default NativeStack;
+export default NativeNavigation;
+// export default createAppContainer(ExampleApp);

--- a/Example/nativeNavigation.js
+++ b/Example/nativeNavigation.js
@@ -1,5 +1,13 @@
 import React from 'react';
-import { TextInput, StyleSheet, Button, View, ScrollView } from 'react-native';
+import {
+  TextInput,
+  StyleSheet,
+  Button,
+  Text,
+  View,
+  ScrollView,
+  AsyncStorage,
+} from 'react-native';
 import { createAppContainer } from 'react-navigation';
 import createNativeStackNavigator from 'react-native-screens/createNativeStackNavigator';
 
@@ -32,13 +40,18 @@ class PushScreen extends React.Component {
   render() {
     return (
       <View style={styles.screen}>
+        <Text>{'INDEX ' + this.props.navigation.getParam('index', 0)}</Text>
         <TextInput placeholder="Hello" style={styles.textInput} />
         <Button
           onPress={() => this.props.navigation.goBack()}
           title="Go back"
         />
         <Button
-          onPress={() => this.props.navigation.push('Push')}
+          onPress={() =>
+            this.props.navigation.push('Push', {
+              index: this.props.navigation.getParam('index', 0) + 1,
+            })
+          }
           title="Push more"
         />
         <View style={styles.leftTop} />
@@ -141,4 +154,27 @@ const styles = StyleSheet.create({
   },
 });
 
-export default createAppContainer(App);
+const persistenceKey = 'persistenceKey';
+const persistNavigationState = async navState => {
+  try {
+    await AsyncStorage.setItem(persistenceKey, JSON.stringify(navState));
+  } catch (err) {
+    // handle the error according to your needs
+  }
+};
+const loadNavigationState = async () => {
+  const jsonString = await AsyncStorage.getItem(persistenceKey);
+  console.warn('LOADED', jsonString);
+  return JSON.parse(jsonString);
+};
+
+const AppContainer = createAppContainer(App);
+
+const AppX = () => (
+  <AppContainer
+    persistNavigationState={persistNavigationState}
+    loadNavigationState={loadNavigationState}
+  />
+);
+
+export default AppX;

--- a/Example/nativeStack.js
+++ b/Example/nativeStack.js
@@ -28,7 +28,7 @@ export class Stack extends Component {
     super(props);
 
     this.state = {
-      stack: ['azure'],
+      stack: ['azure', 'pink', 'cyan'],
       transitioning: 0,
     };
   }

--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -27,7 +27,6 @@ function renderComponentOrThunk(componentOrThunk, props) {
 
 class StackView extends React.Component {
   _removeScene = route => {
-    console.warn('DISMISSED', route.key);
     const { navigation } = this.props;
     navigation.dispatch(
       NavigationActions.back({
@@ -183,7 +182,6 @@ class StackView extends React.Component {
 
   render() {
     const { navigation, descriptors } = this.props;
-    console.warn('RUTS', navigation.state.routes.length);
 
     return (
       <ScreenStack style={styles.scenes}>

--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -27,6 +27,7 @@ function renderComponentOrThunk(componentOrThunk, props) {
 
 class StackView extends React.Component {
   _removeScene = route => {
+    console.warn('DISMISSED', route.key);
     const { navigation } = this.props;
     navigation.dispatch(
       NavigationActions.back({
@@ -182,6 +183,7 @@ class StackView extends React.Component {
 
   render() {
     const { navigation, descriptors } = this.props;
+    console.warn('RUTS', navigation.state.routes.length);
 
     return (
       <ScreenStack style={styles.scenes}>

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -211,6 +211,11 @@
   return nil;
 }
 
+- (BOOL)canBecomeFirstResponder
+{
+  return YES;
+}
+
 - (void)willMoveToParentViewController:(UIViewController *)parent
 {
   if (parent == nil) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-screens",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.10",
   "description": "First incomplete navigation solution for your react-native app.",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
I upgraded to the latest alpha and noticed some `console.warn`'s triggering in development without coming from my own code.

Are the `console.warn`'s there intentionally? Or are they leftover from debugging? 

If you'd prefer to leave them in, is there a babel plugin that could be added to remove these warnings before publishing to npm?

![image](https://user-images.githubusercontent.com/709451/68829332-6c7bcf80-065d-11ea-9692-14e78c952d85.png)
