### PR TITLE
Use containedTransparentModal in RNN wrapper when requested.

### DIFF
--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -159,8 +159,13 @@ class StackView extends React.Component {
 
     let stackPresentation = 'push';
     if (mode === 'modal' || mode === 'containedModal') {
-      stackPresentation =
-        transparentCard || options.cardTransparent ? 'transparentModal' : mode;
+      stackPresentation = mode;
+      if (transparentCard || options.cardTransparent) {
+        stackPresentation =
+          mode === 'containedModal'
+            ? 'containedTransparentModal'
+            : 'transparentModal';
+      }
     }
 
     let stackAnimation;


### PR DESCRIPTION
Previously when transparent card was requested we'd default to transparentModal stack presentation mode. However if user requests contained modal mode we should be using containedTransparentModal instead. This change fixes that behavior.