### PR TITLE
Fix not displaying view in navigation

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -31,12 +31,6 @@
   return self;
 }
 
-- (void)reactSetFrame:(CGRect)frame
-{
-  // ignore setFrame call from react, the frame of this view
-  // is controlled by the UIViewController it is contained in
-}
-
 - (void)updateBounds
 {
   [_bridge.uiManager setSize:self.bounds.size forView:self];

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -31,6 +31,15 @@
   return self;
 }
 
+- (void)reactSetFrame:(CGRect)frame
+{
+  if (_active) {
+    [super reactSetFrame:frame];
+  }
+  // ignore setFrame call from react, the frame of this view
+  // is controlled by the UIViewController it is contained in
+}
+
 - (void)updateBounds
 {
   [_bridge.uiManager setSize:self.bounds.size forView:self];


### PR DESCRIPTION
fixes https://github.com/kmagiera/react-native-screens/issues/208

For stack overriding `reactSetFrame` for `active` does nothing because `active` is always `NO`, so there's no regression.

But it fixes in other cases (like stack navigation - not native one).