### PR TITLE
Add support for customizing back button image.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -8,6 +8,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.appcompat.app.ActionBar;
@@ -15,6 +16,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.views.text.ReactFontManager;
 
 import java.util.ArrayList;
@@ -183,6 +185,17 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     for (int i = 0, size = mConfigSubviews.size(); i < size; i++) {
       ScreenStackHeaderSubview view = mConfigSubviews.get(i);
       ScreenStackHeaderSubview.Type type = view.getType();
+
+      if (type == ScreenStackHeaderSubview.Type.BACK) {
+        // we special case BACK button header config type as we don't add it as a view into toolbar
+        // but instead just copy the drawable from imageview that's added as a first child to it.
+        View firstChild = view.getChildAt(0);
+        if (!(firstChild instanceof ImageView)) {
+          throw new JSApplicationIllegalArgumentException("Back button header config view should have Image as first child");
+        }
+        actionBar.setHomeAsUpIndicator(((ImageView) firstChild).getDrawable());
+        continue;
+      }
 
       Toolbar.LayoutParams params =
               new Toolbar.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.java
@@ -18,7 +18,8 @@ public class ScreenStackHeaderSubview extends ReactViewGroup {
     LEFT,
     CENTER,
     TITLE,
-    RIGHT
+    RIGHT,
+    BACK
   }
 
   private int mReactWidth, mReactHeight;

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubviewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubviewManager.java
@@ -47,6 +47,8 @@ public class ScreenStackHeaderSubviewManager extends ReactViewManager {
       view.setType(ScreenStackHeaderSubview.Type.TITLE);
     } else if ("right".equals(type)) {
       view.setType(ScreenStackHeaderSubview.Type.RIGHT);
+    } else if ("back".equals(type)) {
+      view.setType(ScreenStackHeaderSubview.Type.BACK);
     }
   }
 }

--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -12,6 +12,7 @@ import {
   ScreenStack,
   Screen,
   ScreenStackHeaderConfig,
+  ScreenStackHeaderBackButtonImage,
   ScreenStackHeaderLeftView,
   ScreenStackHeaderRightView,
   ScreenStackHeaderTitleView,
@@ -92,6 +93,12 @@ class StackView extends React.Component {
     }
 
     const children = [];
+
+    if (options.backButtonImage) {
+      children.push(
+        <ScreenStackHeaderBackButtonImage source={options.backButtonImage} />
+      );
+    }
 
     if (options.headerLeft !== undefined) {
       children.push(

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -34,6 +34,7 @@
 @end
 
 typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
+  RNSScreenStackHeaderSubviewTypeBackButton,
   RNSScreenStackHeaderSubviewTypeLeft,
   RNSScreenStackHeaderSubviewTypeRight,
   RNSScreenStackHeaderSubviewTypeTitle,

--- a/src/screens.native.js
+++ b/src/screens.native.js
@@ -151,7 +151,7 @@ const ScreenStackHeaderBackButtonImage = props => (
   <ScreensNativeModules.NativeScreenStackHeaderSubview
     type="back"
     style={styles.headerSubview}>
-    <Image {...props} />
+    <Image resizeMode="center" fadeDuration={0} {...props} />
   </ScreensNativeModules.NativeScreenStackHeaderSubview>
 );
 

--- a/src/screens.native.js
+++ b/src/screens.native.js
@@ -4,6 +4,7 @@ import {
   requireNativeComponent,
   View,
   UIManager,
+  Image,
   StyleSheet,
 } from 'react-native';
 import { version } from 'react-native/Libraries/Core/ReactNativeVersion';
@@ -146,6 +147,14 @@ const styles = StyleSheet.create({
   },
 });
 
+const ScreenStackHeaderBackButtonImage = props => (
+  <ScreensNativeModules.NativeScreenStackHeaderSubview
+    type="back"
+    style={styles.headerSubview}>
+    <Image {...props} />
+  </ScreensNativeModules.NativeScreenStackHeaderSubview>
+);
+
 const ScreenStackHeaderRightView = props => (
   <ScreensNativeModules.NativeScreenStackHeaderSubview
     {...props}
@@ -198,6 +207,7 @@ module.exports = {
   get ScreenStackHeaderSubview() {
     return ScreensNativeModules.NativeScreenStackHeaderSubview;
   },
+  ScreenStackHeaderBackButtonImage,
   ScreenStackHeaderRightView,
   ScreenStackHeaderLeftView,
   ScreenStackHeaderTitleView,


### PR DESCRIPTION
For customizing back button image we use platform native functionality that is: `setBackIndicatorImage` on iOS and `setHomeAsUpIndicator` on Android.
The reason we don't do that just by setting left item is that we get a couple of things for free such as handling RTL properly, working accessibility features, handling prop for hiding back button and a couple more.

Unfortunately there are some downsides to that approach too. We need to install the back button as an Image component from the JS side, and the extract the image payload on the native side to set it with the navigator. This is specifically problematic in DEV mode where images are loaded asynchronously over HTTP from the packager. In order for that to work we had to employ a few hacks (more comments on that in the code). 