### PR TITLE
Move gestureEnabled config to screen instead of heade…

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -52,6 +52,7 @@ public class Screen extends ViewGroup implements ReactPointerEventsView {
   private boolean mTransitioning;
   private StackPresentation mStackPresentation = StackPresentation.PUSH;
   private StackAnimation mStackAnimation = StackAnimation.DEFAULT;
+  private boolean mGestureEnabled = true;
 
   public Screen(ReactContext context) {
     super(context);
@@ -122,6 +123,10 @@ public class Screen extends ViewGroup implements ReactPointerEventsView {
     mStackAnimation = stackAnimation;
   }
 
+  public void setGestureEnabled(boolean gestureEnabled) {
+    mGestureEnabled = gestureEnabled;
+  }
+
   public StackAnimation getStackAnimation() {
     return mStackAnimation;
   }
@@ -168,5 +173,9 @@ public class Screen extends ViewGroup implements ReactPointerEventsView {
 
   public boolean isActive() {
     return mActive;
+  }
+
+  public boolean isGestureEnabled() {
+    return mGestureEnabled;
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.java
@@ -97,10 +97,6 @@ public class ScreenStackFragment extends ScreenFragment {
   }
 
   public boolean isDismissable() {
-    View child = mScreenView.getChildAt(0);
-    if (child instanceof ScreenStackHeaderConfig) {
-      return ((ScreenStackHeaderConfig) child).isDismissable();
-    }
-    return true;
+    return mScreenView.isGestureEnabled();
   }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -30,7 +30,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private float mTitleFontSize;
   private int mBackgroundColor;
   private boolean mIsHidden;
-  private boolean mGestureEnabled = true;
   private boolean mIsBackButtonHidden;
   private boolean mIsShadowHidden;
   private int mTintColor;
@@ -104,10 +103,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
       }
     }
     return null;
-  }
-
-  public boolean isDismissable() {
-    return mGestureEnabled;
   }
 
   public void onUpdate() {
@@ -287,10 +282,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
   public void setHideShadow(boolean hideShadow) {
     mIsShadowHidden = hideShadow;
-  }
-
-  public void setGestureEnabled(boolean gestureEnabled) {
-    mGestureEnabled = gestureEnabled;
   }
 
   public void setHideBackButton(boolean hideBackButton) {

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -88,11 +88,6 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setHideShadow(hideShadow);
   }
 
-  @ReactProp(name = "gestureEnabled", defaultBoolean = true)
-  public void setGestureEnabled(ScreenStackHeaderConfig config, boolean gestureEnabled) {
-    config.setGestureEnabled(gestureEnabled);
-  }
-
   @ReactProp(name = "hideBackButton")
   public void setHideBackButton(ScreenStackHeaderConfig config, boolean hideBackButton) {
     config.setHideBackButton(hideBackButton);

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java
@@ -57,6 +57,11 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
     }
   }
 
+  @ReactProp(name = "gestureEnabled", defaultBoolean = true)
+  public void setGestureEnabled(Screen view, boolean gestureEnabled) {
+    view.setGestureEnabled(gestureEnabled);
+  }
+
   @Nullable
   @Override
   public Map getExportedCustomDirectEventTypeConstants() {

--- a/createNativeStackNavigator.js
+++ b/createNativeStackNavigator.js
@@ -74,7 +74,6 @@ class StackView extends React.Component {
         headerBackTitleStyle && headerBackTitleStyle.fontFamily,
       backTitleFontSize: headerBackTitleStyle && headerBackTitleStyle.fontSize,
       color: headerTintColor,
-      gestureEnabled: gestureEnabled === undefined ? true : gestureEnabled,
       largeTitle,
       largeTitleFontFamily:
         headerLargeTitleStyle && headerLargeTitleStyle.fontFamily,
@@ -187,6 +186,7 @@ class StackView extends React.Component {
         style={options.cardStyle}
         stackAnimation={stackAnimation}
         stackPresentation={stackPresentation}
+        gestureEnabled={gestureEnabled === undefined ? true : gestureEnabled}
         onAppear={() => this._onSceneFocus(route)}
         onDismissed={() => this._removeScene(route)}>
         {this._renderHeaderConfig(index, route, descriptor)}

--- a/ios/RNSScreen.h
+++ b/ios/RNSScreen.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
 @property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
 @property (nonatomic, retain) UIViewController *controller;
 @property (nonatomic) BOOL active;
+@property (nonatomic) BOOL gestureEnabled;
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
 

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -26,6 +26,7 @@
     _controller = [[RNSScreen alloc] initWithView:self];
     _stackPresentation = RNSScreenStackPresentationPush;
     _stackAnimation = RNSScreenStackAnimationDefault;
+    _gestureEnabled = YES;
   }
 
   return self;
@@ -276,6 +277,7 @@
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(active, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)
 RCT_EXPORT_VIEW_PROPERTY(stackAnimation, RNSScreenStackAnimation)
 RCT_EXPORT_VIEW_PROPERTY(onAppear, RCTDirectEventBlock);

--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -96,7 +96,9 @@
   RCTRootContentView *rootView = (RCTRootContentView *)parent;
   [rootView.touchHandler cancel];
 
-  return _controller.viewControllers.count > 1;
+  RNSScreenView *topScreen = (RNSScreenView *)_controller.viewControllers.lastObject.view;
+
+  return _controller.viewControllers.count > 1 && topScreen.gestureEnabled;
 }
 
 - (void)markChildUpdated

--- a/ios/RNSScreenStackHeaderConfig.h
+++ b/ios/RNSScreenStackHeaderConfig.h
@@ -23,7 +23,6 @@
 @property (nonatomic) BOOL hideBackButton;
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
-@property (nonatomic) BOOL gestureEnabled;
 
 + (void)willShowViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig*)config;
 

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -60,7 +60,6 @@
     self.hidden = YES;
     _translucent = YES;
     _reactSubviews = [NSMutableArray new];
-    _gestureEnabled = YES;
   }
   return self;
 }
@@ -267,10 +266,9 @@
   }
 
   [navctr setNavigationBarHidden:shouldHide animated:YES];
-  navctr.interactivePopGestureRecognizer.enabled = config.gestureEnabled;
 #ifdef __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
-    vc.modalInPresentation = !config.gestureEnabled;
+    vc.modalInPresentation = !config.screenView.gestureEnabled;
   }
 #endif
   if (shouldHide) {
@@ -455,7 +453,6 @@ RCT_EXPORT_VIEW_PROPERTY(hideShadow, BOOL)
 // `hidden` is an UIView property, we need to use different name internally
 RCT_REMAP_VIEW_PROPERTY(hidden, hide, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
 
 @end
 


### PR DESCRIPTION
When you have 2 screens in a stack with the bottom one with gestureEnabled=false using the back gesture causes the screen to become unresponsive. This seems to be caused by setting `interactivePopGestureRecognizer.enabled = NO` as soon as the gesture starts. This causes the gesture to cancel immediately and leaves the screen in an unresponsive state.

```js
<Stack><Screen gestureEnabled={false} /><Screen /></Stack>
```

To fix this instead of using `interactivePopGestureRecognizer.enabled` we can leverage the existing delegate that we have in `RNScreenStack`. In `gestureRecognizerShouldBegin` we can check if the top screen has gestures enabled.

To make this simpler I moved the `gestureEnabled` config to `Screen` instead of `HeaderConfig`. I think it also makes more sense conceptually since the gesture is tied to the screen and not the header. It also simplifies the android code a bit. 

This is a breaking change.

**Update**

This now only moves the config to screen since a separate fix was merged for the bug.