### PR TITLE
Fix detaching views rendered under header config component.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -105,6 +105,14 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     markUpdated();
   }
 
+  protected void removeAllScreens() {
+    for (int i = 0, size = mScreenFragments.size(); i < size; i++) {
+      mScreenFragments.get(i).getScreen().setContainer(null);
+    }
+    mScreenFragments.clear();
+    markUpdated();
+  }
+
   @Override
   public void startViewTransition(View view) {
     super.startViewTransition(view);

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainerViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainerViewManager.java
@@ -35,6 +35,11 @@ public class ScreenContainerViewManager extends ViewGroupManager<ScreenContainer
   }
 
   @Override
+  public void removeAllViews(ScreenContainer parent) {
+    parent.removeAllScreens();
+  }
+
+  @Override
   public int getChildCount(ScreenContainer parent) {
     return parent.getScreenCount();
   }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -98,6 +98,12 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   }
 
   @Override
+  protected void removeAllScreens() {
+    mDismissed.clear();
+    super.removeAllScreens();
+  }
+
+  @Override
   protected boolean hasScreen(ScreenFragment screenFragment) {
     return super.hasScreen(screenFragment) && !mDismissed.contains(screenFragment);
   }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -243,6 +243,11 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     maybeUpdate();
   }
 
+  public void removeAllConfigSubviews() {
+    mConfigSubviews.clear();
+    maybeUpdate();
+  }
+
   public void addConfigSubview(ScreenStackHeaderSubview child, int index) {
     mConfigSubviews.add(index, child);
     maybeUpdate();

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -33,6 +33,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
   }
 
   @Override
+  public void removeAllViews(ScreenStackHeaderConfig parent) {
+    parent.removeAllConfigSubviews();
+  }
+
+  @Override
   public void removeViewAt(ScreenStackHeaderConfig parent, int index) {
     parent.removeConfigSubview(index);
   }


### PR DESCRIPTION
This change fixes the problem when header update would get triggered while the header config subviews are not yet fully unmounted. The root cause of this problem is kind of a mystery, I encouneter a crash when going back using back button from a screen that have custom back button image rendered. Turned out that after implementing removeAll schema the problem no longer occurs. I didn't have enough time to investigate it further but supporting removeAll schema is an improvement regardless so going with this solution for now.