### PR TITLE
Fix stack with gestureEnabled=false on iOS

### DIFF
--- a/ios/RNSScreenStack.m
+++ b/ios/RNSScreenStack.m
@@ -102,7 +102,16 @@
   RCTRootContentView *rootView = (RCTRootContentView *)parent;
   [rootView.touchHandler cancel];
 
-  return _controller.viewControllers.count > 1;
+  UIView *topView = _controller.viewControllers.lastObject.view;
+  RNSScreenStackHeaderConfig *config = nil;
+  for (UIView *subview in topView.reactSubviews) {
+    if ([subview isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
+      config = (RNSScreenStackHeaderConfig*) subview;
+      break;
+    }
+  }
+
+  return _controller.viewControllers.count > 1 && (config == nil || config.gestureEnabled);
 }
 
 - (void)markChildUpdated

--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -267,7 +267,6 @@
   }
 
   [navctr setNavigationBarHidden:shouldHide animated:YES];
-  navctr.interactivePopGestureRecognizer.enabled = config.gestureEnabled;
 #ifdef __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     vc.modalInPresentation = !config.gestureEnabled;


### PR DESCRIPTION
https://github.com/kmagiera/react-native-screens/pull/254 without breaking changes

Instead of moving gestureEnabled to the screen we find the header config subview.