### PR TITLE
Fix header transition on Android.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java
@@ -33,6 +33,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private boolean mGestureEnabled = true;
   private boolean mIsBackButtonHidden;
   private boolean mIsShadowHidden;
+  private boolean mDestroyed;
   private int mTintColor;
   private final Toolbar mToolbar;
 
@@ -61,6 +62,10 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   @Override
   protected void onLayout(boolean changed, int l, int t, int r, int b) {
     // no-op
+  }
+
+  public void destroy() {
+    mDestroyed = true;
   }
 
   @Override
@@ -116,7 +121,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     boolean isRoot = stack == null ? true : stack.getRootScreen() == parent;
     boolean isTop = stack == null ? true : stack.getTopScreen() == parent;
 
-    if (!mIsAttachedToWindow || !isTop) {
+    if (!mIsAttachedToWindow || !isTop || mDestroyed) {
       return;
     }
 
@@ -225,7 +230,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   }
 
   private void maybeUpdate() {
-    if (getParent() != null) {
+    if (getParent() != null && !mDestroyed) {
       onUpdate();
     }
   }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.java
@@ -4,10 +4,11 @@ import android.view.View;
 
 import com.facebook.react.bridge.JSApplicationCausedNativeException;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+
+import javax.annotation.Nonnull;
 
 @ReactModule(name = ScreenStackHeaderConfigViewManager.REACT_CLASS)
 public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenStackHeaderConfig> {
@@ -30,6 +31,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
       throw new JSApplicationCausedNativeException("Config children should be of type " + ScreenStackHeaderSubviewManager.REACT_CLASS);
     }
     parent.addConfigSubview((ScreenStackHeaderSubview) child, index);
+  }
+
+  @Override
+  public void onDropViewInstance(@Nonnull ScreenStackHeaderConfig view) {
+    view.destroy();
   }
 
   @Override


### PR DESCRIPTION
This change prevents toolbar from updating when there is a transition happening to the view. This fixes the issue where header subviews would disappear when going back from a given screen. The root cause was that the config view manager would trigger subviews removal and re-layout itself. As aresult if we had a custom back button that back button would get removed and the title would move into its place while the screen animation is running. In order to prevent that we hook into View Manager's onDropViewInstance to notify header config that it is about to be destroyed. This in turn prevents any updates to be made to the toolbar config.