### PR TITLE
[Android] update view when go back to previous screen

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.java
@@ -240,6 +240,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
   protected void onAttachedToWindow() {
     super.onAttachedToWindow();
     mIsAttached = true;
+    mNeedUpdate = true;
     mFragmentManager = findFragmentManager();
     updateIfNeeded();
   }
@@ -253,6 +254,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     mFragmentManager = null;
     // so we don't add the same screen twice after re-attach
     removeAllViews();
+    mActiveScreenFragments.clear();
     // after re-attach we'll update the screen and add views again
     markUpdated();
   }


### PR DESCRIPTION
This PR fixes an issue when screen container does not get updated properly after being detached and re-attached on Android. An example where this bug surfaces is when we have a screens based tabs rendered inside stack container. When we push new screen on top of tabs the tabs container is detached, then after going back to that screen we don't get the selected tab displayed but instead we see an empty screen (issue reported in #272).

The root cause of the issue is that we clean all child views when container detaches but we don't clear `mActiveScreenFragments` array which keeps track on what fragments have been attached. After the container is re-attached it occurs to the container as if it has a screen already installed while all the children are removed. Clearing `mActiveScreenFragments` along removing views fixes this problem.