### PR TITLE
Fix typo in `onDismissed` prop name

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Screen stack component expects one or more `Screen` components as direct childre
 
 `StackScreen` extends the capabilities of `Screen` component to allow additional customizations and to make it possible to handle events such as using hardware back or back gesture to dismiss the top screen. Below is the list of additional properties that can be used for `Screen` component:
 
-#### `onDismiss`
+#### `onDismissed`
 
 A callback that gets called when the current screen is dismissed by hardware back (on Android) or dismiss gesture (swipe back or down). The callback takes no arguments.
 


### PR DESCRIPTION
The prop is called `onDismissed` according to the code

https://github.com/kmagiera/react-native-screens/blob/e00a08a3dc8d96eabb391725d6af57f28d78e300/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.java#L65
https://github.com/kmagiera/react-native-screens/blob/e00a08a3dc8d96eabb391725d6af57f28d78e300/ios/RNSScreen.h#L43