### PR TITLE
Fix NPE on nested stack detach on Android.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -70,14 +70,16 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
 
   @Override
   protected void onDetachedFromWindow() {
-    mFragmentManager.removeOnBackStackChangedListener(mBackStackListener);
-    mFragmentManager.unregisterFragmentLifecycleCallbacks(mLifecycleCallbacks);
-    if (!mFragmentManager.isStateSaved()) {
-      // state save means that the container where fragment manager was installed has been unmounted.
-      // This could happen as a result of dismissing nested stack. In such a case we don't need to
-      // reset back stack as it'd result in a crash caused by the fact the fragment manager is no
-      // longer attached.
-      mFragmentManager.popBackStack(BACK_STACK_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+    if (mFragmentManager != null) {
+      mFragmentManager.removeOnBackStackChangedListener(mBackStackListener);
+      mFragmentManager.unregisterFragmentLifecycleCallbacks(mLifecycleCallbacks);
+      if (!mFragmentManager.isStateSaved()) {
+        // state save means that the container where fragment manager was installed has been unmounted.
+        // This could happen as a result of dismissing nested stack. In such a case we don't need to
+        // reset back stack as it'd result in a crash caused by the fact the fragment manager is no
+        // longer attached.
+        mFragmentManager.popBackStack(BACK_STACK_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+      }
     }
     super.onDetachedFromWindow();
   }


### PR DESCRIPTION
This change fixes crash caused when nested stack is detached due to the parent stack being closed. As a result we may end up in a situation when fragment manager is not yet set despite onDetach callback being call. When fragment manager is not set we can also ignore the operations we should've performed in on detach. This change adds a null check before we call into fragment manager in on detach callback.