### PR TITLE
Fix rendering title view in native header on Android.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubview.java
@@ -43,18 +43,15 @@ public class ScreenStackHeaderSubview extends ReactViewGroup {
 
   @Override
   protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-    if (changed && (mType == Type.CENTER || mType == Type.TITLE)) {
+    if (changed && (mType == Type.CENTER)) {
+      // if we want the view to be centered we need to account for the fact that right and left
+      // paddings may not be equal.
       Measurements measurements = new Measurements();
-      measurements.width = right - left;
-      if (mType == Type.CENTER) {
-        // if we want the view to be centered we need to account for the fact that right and left
-        // paddings may not be equal.
-        View parent = (View) getParent();
-        int parentWidth = parent.getWidth();
-        int rightPadding = parentWidth - right;
-        int leftPadding = left;
-        measurements.width = Math.max(0, parentWidth - 2 * Math.max(rightPadding, leftPadding));
-      }
+      View parent = (View) getParent();
+      int parentWidth = parent.getWidth();
+      int rightPadding = parentWidth - right;
+      int leftPadding = left;
+      measurements.width = Math.max(0, parentWidth - 2 * Math.max(rightPadding, leftPadding));
       measurements.height = bottom - top;
       mUIManager.setViewLocalData(getId(), measurements);
     }


### PR DESCRIPTION
This change removes the behavior that's been added for an unclear reason. We may consider reverting this one, however I was unable to reproduce a problem when setting header title view layout measurements was necessary. To the contrary it was causing issues in the case when the title header view updates. In such a case we would never update width/height so the updated view might be cropped. In addition we are changing the way we schedule native layout updates. Previously we'd use handler.post but it was causing one frame delay so this change migrates us to use choreographer.