### PR TITLE
Fix updating native header on iOS while transition is ongoing.

### DIFF
--- a/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/RNSScreenStackHeaderConfig.m
@@ -96,7 +96,16 @@
 {
   UIViewController *vc = _screenView.controller;
   UINavigationController *nav = (UINavigationController*) vc.parentViewController;
-  if (vc != nil && nav.visibleViewController == vc) {
+  UIViewController *nextVC = nav.visibleViewController;
+  if (nav.transitionCoordinator != nil) {
+    // if navigator is performing transition instead of allowing to update of `visibleConttroller`
+    // we look at `topController`. This is because during transitiong the `visibleController` won't
+    // point to the controller that is going to be revealed after transition. This check fixes the
+    // problem when config gets updated while the transition is ongoing.
+    nextVC = nav.topViewController;
+  }
+
+  if (vc != nil && nextVC == vc) {
     [RNSScreenStackHeaderConfig updateViewController:self.screenView.controller withConfig:self];
   }
 }


### PR DESCRIPTION
This change fixes a bug when header property updates happens during or at the same time of stack transition, e.g., when we both pop a screen and change parent VC header properties. When this happens we trigger header update code, but because we used to compare current VC to visibleViewController, which at that moment points to controller that we are transitioning away from, the update would've been prevented. With this change instead of using visibleViewController to compare with updated VC, we check if there is transition happening (using transitransitionCoordinator property), and in such case we use topController which points to the controller we are transitioning to.