### PR TITLE
Fix text selection inside screen container on Android.

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.java
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Paint;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 
@@ -12,8 +13,6 @@ import androidx.fragment.app.Fragment;
 
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.uimanager.PointerEvents;
-import com.facebook.react.uimanager.ReactPointerEventsView;
 import com.facebook.react.uimanager.UIManagerModule;
 
 public class Screen extends ViewGroup {
@@ -56,6 +55,17 @@ public class Screen extends ViewGroup {
 
   public Screen(ReactContext context) {
     super(context);
+    // we set layout params as WindowManager.LayoutParams to workaround the issue with TextInputs
+    // not displaying modal menus (e.g., copy/paste or selection). The missing menus are due to the
+    // fact that TextView implementation is expected to be attached to window when layout happens.
+    // Then, at the moment of layout it checks whether window type is in a reasonable range to tell
+    // whether it should enable selection controlls (see Editor.java#prepareCursorControllers).
+    // With screens, however, the text input component can be laid out before it is attached, in that
+    // case TextView tries to get window type property from the oldest existing parent, which in this
+    // case is a Screen class, as it is the root of the screen that is about to be attached. Setting
+    // params this way is not the most elegant way to solve this problem but workarounds it for the
+    // time being
+    setLayoutParams(new WindowManager.LayoutParams(WindowManager.LayoutParams.TYPE_APPLICATION));
   }
 
   @Override


### PR DESCRIPTION
This change fixes the problem with missing text selection modals when text input component is rendered under screen container (reported in #205) . The reason turned out to be a problem with Android TextView implementation which expect the component to be attached to window at the moment when layout happens (see Editor.java#prepareCursorControllers and TextView.java$makeNewLayout). Apparently, within screens container layout will happen before the component of a given screen are attached (because attaching is managed by the fragment manager which delays the moment at which the screen is attached). As a result the textView component does not get a chance to fetch proper window layout params such that it can tell whether it should support selection mode or not. We workaround this issue by providing window layout params directly from Screen class which is used instead of the DecorWindow in case TextView is not yet attached (it searches for the top-most parent when not attached).