### PR TITLE
fix(android): NullPointerException crash due to null top screen

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.java
@@ -50,7 +50,7 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   }
 
   public Screen getTopScreen() {
-    return mTopScreen.getScreen();
+    return mTopScreen != null ? mTopScreen.getScreen() : null;
   }
 
   public Screen getRootScreen() {


### PR DESCRIPTION
The library would crash when the `mTopScreen` instance variable is null. This change checks if it null before calling the `getScreen()` method. It also marks the method as having a nullable return value. The only place this method is used is already setup to handle `null` responses.